### PR TITLE
DEV-7688 Make Beauty HTTP 1_1 compatible_host_header

### DIFF
--- a/src/request_parser.cpp
+++ b/src/request_parser.cpp
@@ -57,10 +57,6 @@ RequestParser::result_type RequestParser::consume(Request &req,
         case uri:
             if (input == ' ') {
                 state_ = http_version_h;
-            } else if (input == '\r') {
-                req.httpVersionMajor_ = 0;
-                req.httpVersionMinor_ = 9;
-                return good_complete;
             } else if (isCtl(input)) {
                 return bad;
             } else {


### PR DESCRIPTION
This PR considered making the Host header required (as it is a MUST requirement in RFC9112 sec 3.2)
I opted not to do it for as the low level API that request handler provides makes it very easy to enforce this rule (or not) if needed as all header are accessible in the Request object. 
It will also cost an extra for loop for finding the Host header which is not ideal when e.g. used in embedded systems.
Any HTTP/1.0 clients will just work too.

However I did update all unit tests so tests request include Host header. This way it will be a clean addition of adding a test + implementation if we want to add this rule in the future.
