### PR TITLE
DEV-7688 Make Beauty HTTP 1_1 compatible_content_len

### DIFF
--- a/src/beauty/reply.hpp
+++ b/src/beauty/reply.hpp
@@ -37,6 +37,7 @@ class Reply {
         forbidden = 403,
         not_found = 404,
         method_not_allowed = 405,
+        length_required = 411,
         internal_server_error = 500,
         not_implemented = 501,
         bad_gateway = 502,

--- a/src/beauty/request.hpp
+++ b/src/beauty/request.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <limits>
 
 #include "beauty/header.hpp"
 
@@ -75,7 +76,8 @@ struct Request {
         headers_.clear();
         requestPath_.clear();
         body_.clear();
-        contentLength_ = 0;
+        contentLength_ = std::numeric_limits<size_t>::max();
+        isChunked_ = false;
         queryParams_.clear();
         formParams_.clear();
     }
@@ -101,7 +103,8 @@ struct Request {
     }
 
     size_t noInitialBodyBytesReceived_ = 0;
-    size_t contentLength_ = 0;
+    size_t contentLength_ = std::numeric_limits<size_t>::max();  // means not specified
+    bool isChunked_ = false;
 };
 
 }  // namespace beauty

--- a/src/beauty/request_parser.hpp
+++ b/src/beauty/request_parser.hpp
@@ -19,7 +19,7 @@ class RequestParser {
         good_complete,
         good_part,
         bad,
-        not_implemented,
+        missing_content_length,
         version_not_supported,
         indeterminate
     };
@@ -33,7 +33,8 @@ class RequestParser {
     // Handle the next character of input.
     result_type consume(Request &req, std::vector<char> &content, char input);
 
-    result_type actOnHeaderValueIfNeeded(Request &req, std::vector<char> &content);
+    void storeHeaderValueIfNeeded(Request &req, std::vector<char> &content);
+    result_type checkRequestAfterAllHeaders(Request &req);
 
     // The current state of the parser.
     enum state {

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -77,8 +77,8 @@ void Connection::doRead() {
                         reply_.stockReply(Reply::bad_request);
                         doWriteHeaders();
                     }
-                } else if (result == RequestParser::not_implemented) {
-                    reply_.stockReply(Reply::not_implemented);
+                } else if (result == RequestParser::missing_content_length) {
+                    reply_.stockReply(Reply::length_required);
                     doWriteHeaders();
                 } else if (result == RequestParser::version_not_supported) {
                     reply_.stockReply(Reply::status_type::version_not_supported);
@@ -127,13 +127,15 @@ void Connection::doReadBody() {
                 unsigned multiPartCounter = reply_.multiPartCounter_;
 
                 requestHandler_.handlePartialWrite(connectionId_, request_, buffer_, reply_);
-                if (reply_.noBodyBytesReceived_ < request_.contentLength_) {
-                    if (multiPartCounter != reply_.multiPartCounter_) {
-                        doWritePartAck();
-                    } else {
-                        doReadBody();
+                if (request_.contentLength_ != std::numeric_limits<size_t>::max() &&
+                    reply_.noBodyBytesReceived_ < request_.contentLength_) {
+                        if (multiPartCounter != reply_.multiPartCounter_) {
+                            doWritePartAck();
+                        } else {
+                            doReadBody();
+                        }
                     }
-                } else {
+                else {
                     doWriteHeaders();
                 }
             } else if (ec != asio::error::operation_aborted) {

--- a/src/reply.cpp
+++ b/src/reply.cpp
@@ -18,6 +18,7 @@ const std::string bad_request = "HTTP/1.1 400 Bad Request\r\n";
 const std::string unauthorized = "HTTP/1.1 401 Unauthorized\r\n";
 const std::string forbidden = "HTTP/1.1 403 Forbidden\r\n";
 const std::string not_found = "HTTP/1.1 404 Not Found\r\n";
+const std::string length_required = "HTTP/1.1 411 Length Required\r\n";
 const std::string internal_server_error = "HTTP/1.1 500 Internal Server Error\r\n";
 const std::string not_implemented = "HTTP/1.1 501 Not Implemented\r\n";
 const std::string bad_gateway = "HTTP/1.1 502 Bad Gateway\r\n";
@@ -50,6 +51,8 @@ asio::const_buffer toBuffer(Reply::status_type status) {
             return asio::buffer(forbidden);
         case Reply::not_found:
             return asio::buffer(not_found);
+        case Reply::length_required:
+            return asio::buffer(length_required);
         case Reply::internal_server_error:
             return asio::buffer(internal_server_error);
         case Reply::not_implemented:
@@ -198,6 +201,11 @@ const char not_found[] =
     "<head><title>Not Found</title></head>"
     "<body><h1>404 Not Found</h1></body>"
     "</html>";
+const char length_required[] =
+    "<html>"
+    "<head><title>Length required</title></head>"
+    "<body><h1>411 Length Required</h1></body>"
+    "</html>";
 const char internal_server_error[] =
     "<html>"
     "<head><title>Internal Server Error</title></head>"
@@ -252,6 +260,8 @@ std::vector<char> toArray(Reply::status_type status) {
             return std::vector<char>(forbidden, forbidden + sizeof(forbidden));
         case Reply::not_found:
             return std::vector<char>(not_found, not_found + sizeof(not_found));
+        case Reply::length_required:
+            return std::vector<char>(length_required, length_required + sizeof(length_required));
         case Reply::internal_server_error:
             return std::vector<char>(internal_server_error,
                                      internal_server_error + sizeof(internal_server_error));


### PR DESCRIPTION
This PR implements 411 Length Required. This is required by HTTP/1.1 whenever Content-Length is missing.
It also changes the previous status 501 for chunked transfer encoding to 411 as this is more accurate.
A couple of malformed unrelated tests was also fixed as Content-Length now is checked for.

It was tested with this python script that modified with using Content-Length or not chunked transfer-encoding or not.
```
import socket

host = "127.0.0.1"
port = 8080

request = (
        "POST /upload HTTP/1.1\r\n"
        "Host: example.com\r\n"
 #       "Transfer-Encoding: chunked\r\n"
        "Content-Type: text/plain\r\n"
#        "Content-Length: 13"\r\n
        "\r\n"
        "5\r\n"
        "Hello\r\n"
        "7\r\n"
        ", World!\r\n"
        "0\r\n"
        "\r\n"
        )

# Create a socket and send the request
with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
    s.connect((host, port))
    s.sendall(request.encode())
    response = s.recv(4096)
    print(response.decode())
```
Chunked:
<img width="404" height="99" alt="image" src="https://github.com/user-attachments/assets/d9f7d857-a935-4132-88c3-f04e2f26a6fc" />

Chunked + Content-Lengh:
<img width="404" height="99" alt="image" src="https://github.com/user-attachments/assets/9fcd7953-ca88-4b92-a0e4-362f71d75205" />

Missing Content-Length:
<img width="404" height="99" alt="image" src="https://github.com/user-attachments/assets/eab2f2e4-e8fa-4fcb-a962-2d752ddd772d" />

Successful POST/PUT was also tested with postman using the my_router_api paths.
