### PR TITLE
Adds base64 encoding/decoding with zero alloc

### DIFF
--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -20,6 +20,12 @@ static const int B64index[256] = {
     19, 20, 21, 22, 23, 24, 25, 0,  0,  0,  0,  63, 0,  26, 27, 28, 29, 30, 31, 32, 33,
     34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
 
+// Helper function to check if a character is a valid base64 character
+static inline bool is_base64_char(unsigned char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '+' ||
+           c == '/' || c == '=';
+}
+
 /**
  * base64_encode - Base64 encode
  * @src: Data to be encoded
@@ -28,7 +34,7 @@ static const int B64index[256] = {
  * Returns: Allocated buffer of out_len bytes of encoded data,
  * or empty string on failure
  */
-std::string base64_encode(const unsigned char *src, size_t len) {
+std::string base64_encode(const unsigned char* src, size_t len) {
     unsigned char *out, *pos;
     const unsigned char *end, *in;
 
@@ -41,7 +47,7 @@ std::string base64_encode(const unsigned char *src, size_t len) {
 
     std::string outStr;
     outStr.resize(olen);
-    out = (unsigned char *)&outStr[0];
+    out = (unsigned char*)&outStr[0];
 
     end = src + len;
     in = src;
@@ -69,8 +75,8 @@ std::string base64_encode(const unsigned char *src, size_t len) {
     return outStr;
 }
 
-std::string base64_decode(const void *data, const size_t len) {
-    unsigned char *p = (unsigned char *)data;
+std::string base64_decode(const void* data, const size_t len) {
+    unsigned char* p = (unsigned char*)data;
     int pad = len > 0 && (len % 4 || p[len - 1] == '=');
     const size_t L = ((len + 3) / 4 - pad) * 4;
     std::string str(L / 4 * 3 + pad, '\0');
@@ -92,6 +98,112 @@ std::string base64_decode(const void *data, const size_t len) {
         }
     }
     return str;
+}
+
+/**
+ * base64_encode_to_buffer - Base64 encode directly to provided buffer (zero allocation)
+ * @src: Data to be encoded
+ * @len: Length of the data to be encoded
+ * @out: Output buffer (must be large enough: at least ((len + 2) / 3) * 4 + 1 bytes)
+ * @out_size: Size of output buffer
+ * Returns: Number of bytes written (excluding null terminator), or 0 on error
+ */
+size_t base64_encode_to_buffer(const unsigned char* src, size_t len, char* out, size_t out_size) {
+    const unsigned char *end, *in;
+    char* pos;
+
+    if (len == 0) {
+        *out = '\0';
+        return 0;
+    }
+
+    size_t olen = 4 * ((len + 2) / 3); /* 3-byte blocks to 4-byte */
+
+    if (olen < len)
+        return 0; /* integer overflow */
+
+    if (out_size < olen + 1)  // +1 for null terminator
+        return 0;             /* buffer too small */
+
+    end = src + len;
+    in = src;
+    pos = out;
+
+    while (end - in >= 3) {
+        *pos++ = base64_table[in[0] >> 2];
+        *pos++ = base64_table[((in[0] & 0x03) << 4) | (in[1] >> 4)];
+        *pos++ = base64_table[((in[1] & 0x0f) << 2) | (in[2] >> 6)];
+        *pos++ = base64_table[in[2] & 0x3f];
+        in += 3;
+    }
+
+    if (end - in) {
+        *pos++ = base64_table[in[0] >> 2];
+        if (end - in == 1) {
+            *pos++ = base64_table[(in[0] & 0x03) << 4];
+            *pos++ = '=';
+        } else {
+            *pos++ = base64_table[((in[0] & 0x03) << 4) | (in[1] >> 4)];
+            *pos++ = base64_table[(in[1] & 0x0f) << 2];
+        }
+        *pos++ = '=';
+    }
+
+    *pos = '\0';  // Null terminate
+    return pos - out;
+}
+
+/**
+ * base64_decode_to_buffer - Base64 decode directly to provided buffer (zero allocation)
+ * @data: Base64 encoded data
+ * @len: Length of the encoded data
+ * @out: Output buffer (must be large enough: at least (len / 4) * 3 bytes)
+ * @out_size: Size of output buffer
+ * Returns: Number of bytes written, or 0 on error
+ */
+size_t base64_decode_to_buffer(const void* data, size_t len, unsigned char* out, size_t out_size) {
+    const unsigned char* p = (const unsigned char*)data;
+
+    if (len == 0) {
+        return 0;  // Empty input
+    }
+
+    // Validate input characters
+    for (size_t i = 0; i < len; ++i) {
+        if (!is_base64_char(p[i])) {
+            return 0;  // Invalid character found
+        }
+    }
+
+    // Handle non-padded base64 (like the original base64_decode function)
+    int pad = len > 0 && (len % 4 || p[len - 1] == '=');
+    const size_t L = ((len + 3) / 4 - pad) * 4;
+    size_t decoded_len = L / 4 * 3 + pad;
+
+    if (out_size < decoded_len) {
+        return 0;  // Buffer too small
+    }
+
+    size_t j = 0;
+    for (size_t i = 0; i < L; i += 4) {
+        int n = B64index[p[i]] << 18 | B64index[p[i + 1]] << 12 | B64index[p[i + 2]] << 6 |
+                B64index[p[i + 3]];
+        out[j++] = n >> 16;
+        out[j++] = n >> 8 & 0xFF;
+        out[j++] = n & 0xFF;
+    }
+
+    if (pad) {
+        int n = B64index[p[L]] << 18 | B64index[p[L + 1]] << 12;
+        out[j++] = n >> 16;
+
+        if (len > L + 2 && p[L + 2] != '=') {
+            n |= B64index[p[L + 2]] << 6;
+            out[j++] = n >> 8 & 0xFF;
+        }
+    }
+
+    return j;
 }
 
 }  // namespace beauty

--- a/src/beauty/base64.hpp
+++ b/src/beauty/base64.hpp
@@ -8,4 +8,14 @@ namespace beauty {
 std::string base64_encode(const unsigned char* src, size_t len);
 std::string base64_decode(const void* data, const size_t len);
 
+// Zero-allocation version: encodes directly to provided buffer
+// Returns number of bytes written (not including null terminator)
+// Buffer must be at least ((len + 2) / 3) * 4 bytes + 1 for null terminator
+size_t base64_encode_to_buffer(const unsigned char* src, size_t len, char* out, size_t out_size);
+
+// Zero-allocation version: decodes directly to provided buffer
+// Returns number of bytes written, or 0 on error
+// Buffer must be at least (len / 4) * 3 bytes (decoded data is always smaller than encoded)
+size_t base64_decode_to_buffer(const void* data, size_t len, unsigned char* out, size_t out_size);
+
 }  // namespace beauty

--- a/test/base64_test.cpp
+++ b/test/base64_test.cpp
@@ -1,16 +1,282 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <vector>
+#include <cstring>
 #include "beauty/base64.hpp"
 
 using namespace beauty;
 
-TEST_CASE("encode", "[base64]") {
+TEST_CASE("base64_encode", "[base64]") {
     SECTION("it should encode example from RFC6455") {
         std::vector<unsigned char> data = {0xb3, 0x7a, 0x4f, 0x2c, 0xc0, 0x62, 0x4f,
                                            0x16, 0x90, 0xf6, 0x46, 0x06, 0xcf, 0x38,
                                            0x59, 0x45, 0xb2, 0xbe, 0xc4, 0xea};
         auto res = base64_encode(&data[0], data.size());
         REQUIRE(res == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+    }
+
+    SECTION("it should encode empty data") {
+        std::vector<unsigned char> data = {};
+        auto res = base64_encode(data.data(), data.size());
+        REQUIRE(res == "");
+    }
+
+    SECTION("it should encode single byte") {
+        std::vector<unsigned char> data = {0x41};  // 'A'
+        auto res = base64_encode(&data[0], data.size());
+        REQUIRE(res == "QQ==");
+    }
+
+    SECTION("it should encode two bytes") {
+        std::vector<unsigned char> data = {0x41, 0x42};  // 'AB'
+        auto res = base64_encode(&data[0], data.size());
+        REQUIRE(res == "QUI=");
+    }
+
+    SECTION("it should encode three bytes") {
+        std::vector<unsigned char> data = {0x41, 0x42, 0x43};  // 'ABC'
+        auto res = base64_encode(&data[0], data.size());
+        REQUIRE(res == "QUJD");
+    }
+
+    SECTION("it should encode simple text") {
+        const char* text = "Hello, World!";
+        auto res = base64_encode(reinterpret_cast<const unsigned char*>(text), strlen(text));
+        REQUIRE(res == "SGVsbG8sIFdvcmxkIQ==");
+    }
+}
+
+TEST_CASE("base64_decode", "[base64]") {
+    SECTION("it should decode example from RFC6455") {
+        char const* encoded = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+        std::string decoded = base64_decode(encoded, strlen(encoded));
+        std::vector<unsigned char> expected = {0xb3, 0x7a, 0x4f, 0x2c, 0xc0, 0x62, 0x4f,
+                                               0x16, 0x90, 0xf6, 0x46, 0x06, 0xcf, 0x38,
+                                               0x59, 0x45, 0xb2, 0xbe, 0xc4, 0xea};
+        REQUIRE(decoded.size() == expected.size());
+        REQUIRE(std::equal(
+            decoded.begin(), decoded.end(), expected.begin(), [](char a, unsigned char b) {
+                return static_cast<unsigned char>(a) == b;
+            }));
+    }
+
+    SECTION("it should decode empty string") {
+        std::string decoded = base64_decode("", 0);
+        REQUIRE(decoded.empty());
+    }
+
+    SECTION("it should decode single byte with padding") {
+        std::string decoded = base64_decode("QQ==", 4);
+        REQUIRE(decoded.size() == 1);
+        REQUIRE(static_cast<unsigned char>(decoded[0]) == 0x41);
+    }
+
+    SECTION("it should decode two bytes with padding") {
+        std::string decoded = base64_decode("QUI=", 4);
+        REQUIRE(decoded.size() == 2);
+        REQUIRE(static_cast<unsigned char>(decoded[0]) == 0x41);
+        REQUIRE(static_cast<unsigned char>(decoded[1]) == 0x42);
+    }
+
+    SECTION("it should decode three bytes without padding") {
+        std::string decoded = base64_decode("QUJD", 4);
+        REQUIRE(decoded.size() == 3);
+        REQUIRE(static_cast<unsigned char>(decoded[0]) == 0x41);
+        REQUIRE(static_cast<unsigned char>(decoded[1]) == 0x42);
+        REQUIRE(static_cast<unsigned char>(decoded[2]) == 0x43);
+    }
+
+    SECTION("it should decode simple text") {
+        std::string decoded = base64_decode("SGVsbG8sIFdvcmxkIQ==", 20);
+        REQUIRE(decoded == "Hello, World!");
+    }
+}
+
+TEST_CASE("base64_encode_to_buffer", "[base64]") {
+    SECTION("it should encode example from RFC6455 to buffer") {
+        std::vector<unsigned char> data = {0xb3, 0x7a, 0x4f, 0x2c, 0xc0, 0x62, 0x4f,
+                                           0x16, 0x90, 0xf6, 0x46, 0x06, 0xcf, 0x38,
+                                           0x59, 0x45, 0xb2, 0xbe, 0xc4, 0xea};
+        char buffer[100];
+        size_t written = base64_encode_to_buffer(data.data(), data.size(), buffer, sizeof(buffer));
+        REQUIRE(written == 28);
+        REQUIRE(std::string(buffer) == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+    }
+
+    SECTION("it should encode empty data to buffer") {
+        char buffer[10];
+        size_t written = base64_encode_to_buffer(nullptr, 0, buffer, sizeof(buffer));
+        REQUIRE(written == 0);
+        REQUIRE(buffer[0] == '\0');
+    }
+
+    SECTION("it should encode single byte to buffer") {
+        unsigned char data[] = {0x41};
+        char buffer[10];
+        size_t written = base64_encode_to_buffer(data, 1, buffer, sizeof(buffer));
+        REQUIRE(written == 4);
+        REQUIRE(std::string(buffer) == "QQ==");
+    }
+
+    SECTION("it should encode simple text to buffer") {
+        const char* text = "Hello, World!";
+        char buffer[100];
+        size_t written = base64_encode_to_buffer(
+            reinterpret_cast<const unsigned char*>(text), strlen(text), buffer, sizeof(buffer));
+        REQUIRE(written == 20);
+        REQUIRE(std::string(buffer) == "SGVsbG8sIFdvcmxkIQ==");
+    }
+
+    SECTION("it should fail with insufficient buffer size") {
+        unsigned char data[] = {0x41, 0x42, 0x43};
+        char buffer[5];  // Need at least 5 bytes (4 + null terminator)
+        size_t written = base64_encode_to_buffer(data, 3, buffer, sizeof(buffer));
+        REQUIRE(written == 4);  // Should succeed with exactly 5 bytes
+
+        char small_buffer[4];  // Too small
+        written = base64_encode_to_buffer(data, 3, small_buffer, sizeof(small_buffer));
+        REQUIRE(written == 0);  // Should fail
+    }
+}
+
+TEST_CASE("base64_decode_to_buffer", "[base64]") {
+    SECTION("it should decode example from RFC6455 to buffer") {
+        char const* encoded = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+        unsigned char buffer[100];
+        size_t written = base64_decode_to_buffer(encoded, strlen(encoded), buffer, sizeof(buffer));
+
+        std::vector<unsigned char> expected = {0xb3, 0x7a, 0x4f, 0x2c, 0xc0, 0x62, 0x4f,
+                                               0x16, 0x90, 0xf6, 0x46, 0x06, 0xcf, 0x38,
+                                               0x59, 0x45, 0xb2, 0xbe, 0xc4, 0xea};
+        REQUIRE(written == expected.size());
+        REQUIRE(std::equal(buffer, buffer + written, expected.begin()));
+    }
+
+    SECTION("it should decode empty string") {
+        unsigned char buffer[10];
+        size_t written = base64_decode_to_buffer("", 0, buffer, sizeof(buffer));
+        REQUIRE(written == 0);
+    }
+
+    SECTION("it should decode single byte with padding to buffer") {
+        unsigned char buffer[10];
+        size_t written = base64_decode_to_buffer("QQ==", 4, buffer, sizeof(buffer));
+        REQUIRE(written == 1);
+        REQUIRE(buffer[0] == 0x41);
+    }
+
+    SECTION("it should decode two bytes with padding to buffer") {
+        unsigned char buffer[10];
+        size_t written = base64_decode_to_buffer("QUI=", 4, buffer, sizeof(buffer));
+        REQUIRE(written == 2);
+        REQUIRE(buffer[0] == 0x41);
+        REQUIRE(buffer[1] == 0x42);
+    }
+
+    SECTION("it should decode three bytes without padding to buffer") {
+        unsigned char buffer[10];
+        size_t written = base64_decode_to_buffer("QUJD", 4, buffer, sizeof(buffer));
+        REQUIRE(written == 3);
+        REQUIRE(buffer[0] == 0x41);
+        REQUIRE(buffer[1] == 0x42);
+        REQUIRE(buffer[2] == 0x43);
+    }
+
+    SECTION("it should decode simple text to buffer") {
+        unsigned char buffer[100];
+        size_t written =
+            base64_decode_to_buffer("SGVsbG8sIFdvcmxkIQ==", 20, buffer, sizeof(buffer));
+        REQUIRE(written == 13);
+        REQUIRE(std::string(reinterpret_cast<char*>(buffer), written) == "Hello, World!");
+    }
+
+    SECTION("it should fail with insufficient buffer size") {
+        unsigned char buffer[2];  // Too small for 3 decoded bytes
+        size_t written = base64_decode_to_buffer("QUJD", 4, buffer, sizeof(buffer));
+        REQUIRE(written == 0);  // Should fail
+    }
+
+    SECTION("it should handle non-padded base64 input") {
+        // "QUJ" is valid non-padded base64 for "AB"
+        unsigned char buffer[10];
+        size_t written = base64_decode_to_buffer("QUJ", 3, buffer, sizeof(buffer));
+        REQUIRE(written == 2);       // Should decode successfully
+        REQUIRE(buffer[0] == 0x41);  // 'A'
+        REQUIRE(buffer[1] == 0x42);  // 'B'
+    }
+
+    SECTION("it should handle non-padded base64 input") {
+        // Non-padded base64 (missing padding characters)
+        unsigned char buffer[10];
+        size_t written = base64_decode_to_buffer("QUJDREVGRw", 10, buffer, sizeof(buffer));
+        REQUIRE(written > 0);        // Should succeed with non-padded input
+        REQUIRE(buffer[0] == 0x41);  // 'A'
+        REQUIRE(buffer[1] == 0x42);  // 'B'
+    }
+
+    SECTION("it should reject invalid base64 characters") {
+        unsigned char buffer[10];
+        // '@' is not a valid base64 character
+        size_t written = base64_decode_to_buffer("QUJ@", 4, buffer, sizeof(buffer));
+        REQUIRE(written == 0);  // Should fail
+    }
+
+    SECTION("it should reject whitespace in input") {
+        unsigned char buffer[10];
+        size_t written = base64_decode_to_buffer("QU JD", 5, buffer, sizeof(buffer));
+        REQUIRE(written == 0);  // Should fail - space is not valid
+    }
+}
+
+TEST_CASE("base64_roundtrip", "[base64]") {
+    SECTION("encode then decode should produce original data") {
+        std::vector<unsigned char> original = {0x00,
+                                               0x01,
+                                               0x02,
+                                               0x03,
+                                               0xFF,
+                                               0xFE,
+                                               0xFD,
+                                               0xFC,
+                                               0x80,
+                                               0x7F,
+                                               0x40,
+                                               0x3F,
+                                               0x20,
+                                               0x1F,
+                                               0x10,
+                                               0x0F};
+
+        // Encode
+        std::string encoded = base64_encode(original.data(), original.size());
+
+        // Decode
+        std::string decoded = base64_decode(encoded.c_str(), encoded.size());
+
+        // Verify
+        REQUIRE(decoded.size() == original.size());
+        REQUIRE(std::equal(
+            decoded.begin(), decoded.end(), original.begin(), [](char a, unsigned char b) {
+                return static_cast<unsigned char>(a) == b;
+            }));
+    }
+
+    SECTION("buffer versions roundtrip should produce original data") {
+        std::vector<unsigned char> original = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE};
+
+        // Encode to buffer
+        char encode_buffer[100];
+        size_t encoded_len = base64_encode_to_buffer(
+            original.data(), original.size(), encode_buffer, sizeof(encode_buffer));
+        REQUIRE(encoded_len > 0);
+
+        // Decode to buffer
+        unsigned char decode_buffer[100];
+        size_t decoded_len = base64_decode_to_buffer(
+            encode_buffer, encoded_len, decode_buffer, sizeof(decode_buffer));
+
+        // Verify
+        REQUIRE(decoded_len == original.size());
+        REQUIRE(std::equal(decode_buffer, decode_buffer + decoded_len, original.begin()));
     }
 }


### PR DESCRIPTION
As the base64 methods may be used for other things than the internal Beauty websocket purpose, this PR extends with two functions that avoids allocating large buffers on the heap. This makes it possible to use these functions for other general purposes.

In addition, more complete unit testing is provided.