### PR TITLE
fix 100_continue_on_esp32

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -450,6 +450,7 @@ void Connection::doWrite100Continue() {
     asio::async_write(socket_,
                       asio::buffer(*continueResponse),
                       [this, self, continueResponse](std::error_code ec, std::size_t) {
+                          (void)continueResponse;
                           if (!ec) {
                               // Initialize reply for body reading - no body bytes received yet
                               reply_.noBodyBytesReceived_ = 0;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -444,22 +444,23 @@ void Connection::handleWriteCompleted() {
 void Connection::doWrite100Continue() {
     auto self(shared_from_this());
 
-    // Create 100 Continue response
-    std::string continueResponse = "HTTP/1.1 100 Continue\r\n\r\n";
+    // Create 100 Continue response as shared_ptr to ensure it outlives the async_write.
+    auto continueResponse = std::make_shared<std::string>("HTTP/1.1 100 Continue\r\n\r\n");
 
-    asio::async_write(
-        socket_, asio::buffer(continueResponse), [this, self](std::error_code ec, std::size_t) {
-            if (!ec) {
-                // Initialize reply for body reading - no body bytes received yet
-                reply_.noBodyBytesReceived_ = 0;
-                // Now read the body using special method for 100-continue
-                doReadBodyAfter100Continue();
-            } else {
-                connectionManager_.debugMsg("doWrite100Continue: " + ec.message() + ':' +
-                                            std::to_string(ec.value()));
-                shutdown();
-            }
-        });
+    asio::async_write(socket_,
+                      asio::buffer(*continueResponse),
+                      [this, self, continueResponse](std::error_code ec, std::size_t) {
+                          if (!ec) {
+                              // Initialize reply for body reading - no body bytes received yet
+                              reply_.noBodyBytesReceived_ = 0;
+                              // Now read the body using special method for 100-continue
+                              doReadBodyAfter100Continue();
+                          } else {
+                              connectionManager_.debugMsg("doWrite100Continue: " + ec.message() +
+                                                          ':' + std::to_string(ec.value()));
+                              shutdown();
+                          }
+                      });
 }
 
 void Connection::doReadBodyAfter100Continue() {


### PR DESCRIPTION
Fix use-after-free bug in Connection::doWrite100Continue() where a local std::string was passed to asio::async_write via asio::buffer().
Since async_write is asynchronous, the local string was destroyed before the write completed, leaving a dangling buffer reference.

On x86 this went unnoticed because the freed stack memory typically wasn't overwritten before the write completed. On ESP32 (32-bit, smaller stacks), the memory was reused immediately, causing garbled output
(�O�O 100 Continue instead of HTTP/1.1 100 Continue) and upload failures for clients using Expect: 100-continue.

Tested on esp32-p4 target with curl.