### PR TITLE
PWS-841 Add http request handling to Beauty

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Beauty was born with the realization that Asio is supported on ESP32 microcontro
   - [🛣️ Router - REST API Simplified](#️-router---rest-api-simplified)
   - [🔌 WebSocket Support](#-websocket-support)
   - [📡 WebSocket Client](#-websocket-client)
+  - [🌐 HTTP Client](#-http-client)
 
 ## 📦 Dependencies
 - **Asio (non-boost)** - Async I/O operations
@@ -1038,6 +1039,96 @@ Two ready-to-run example clients are provided under `examples/pc` (build with
 
 # Terminal 3 - interactive chat client
 ./build/examples/beauty_ws_chat_client_example ws://127.0.0.1:8080/ws/chat
+```
+
+## 🌐 HTTP Client
+
+Beauty also includes an asynchronous HTTP/1.1 client (`HttpClient`) that
+follows the same design principles as the WebSocket client: fixed-size
+buffers, shared `asio::io_context`, and fully callback-driven operation.
+This makes it suitable for device-to-device REST calls (e.g. one ESP32
+querying another) as well as general-purpose HTTP requests.
+
+### Key Features
+
+- **Fixed memory footprint**: Configurable `maxResponseSize` bounds both
+  the receive buffer and the accumulated response body.
+- **Shared event loop**: Runs on the same `io_context` as the server and
+  WebSocket client.
+- **Keep-alive**: Optional TCP connection reuse for sequential requests
+  to the same host.
+- **Request timeout**: Configurable deadline covering resolve, connect,
+  send and receive.
+- **Chunked & EOF-delimited bodies**: The response parser handles
+  `Transfer-Encoding: chunked`, `Content-Length`, and connection-close
+  delimited responses.
+- **1xx interim responses**: Automatically skipped (e.g. `100 Continue`).
+
+### Handling Responses
+
+Implement the `IHttpClientHandler` interface:
+
+```cpp
+#include "beauty/i_http_client_handler.hpp"
+
+class MyHandler : public beauty::IHttpClientHandler {
+public:
+    void onResponse(const beauty::Response& response) override {
+        // response.statusCode_, response.headers_, response.body_
+    }
+
+    void onError(const std::string& error) override {
+        // Timeout, connection refused, parse error, etc.
+    }
+};
+```
+
+### Making Requests
+
+```cpp
+#include "beauty/http_client.hpp"
+
+asio::io_context ioc;
+MyHandler handler;
+
+beauty::HttpClient::Config config;
+config.maxResponseSize  = 4096;               // Max body size (bytes)
+config.requestTimeout   = std::chrono::seconds(5);
+config.keepAlive        = true;               // Reuse connections
+
+auto client = beauty::HttpClient::create(ioc, handler, config);
+
+// Convenience methods
+client->get("http://192.168.1.10:8080/api/status");
+client->post("http://192.168.1.10:8080/api/data",
+             "application/json", "{\"key\":\"value\"}");
+
+// Or the generic request() for any method
+client->request("DELETE", "http://192.168.1.10:8080/api/item/42");
+
+ioc.run();
+```
+
+The `http://` scheme is assumed when no scheme is present, so
+`192.168.1.10:8080/path` works as well.
+
+> **Note:** Only one request may be in flight at a time. Issue the next
+> request from within the `onResponse` / `onError` callback or after it
+> returns.
+
+### Example Client
+
+A ready-to-run example is provided under `examples/pc`:
+
+```bash
+# Start the server demo
+./build/examples/beauty_example 127.0.0.1 8080 www
+
+# GET request
+./build/examples/beauty_http_client_example http://127.0.0.1:8080/index.html
+
+# POST request with body
+./build/examples/beauty_http_client_example http://127.0.0.1:8080/api POST '{"key":"value"}'
 ```
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,3 +43,17 @@ target_include_directories(beauty_ws_chat_client_example PRIVATE
 target_link_libraries(beauty_ws_chat_client_example PRIVATE asio::asio cjson ${CMAKE_PROJECT_NAME})
 
 target_compile_options(beauty_ws_chat_client_example PRIVATE -Wall -Wextra -Wpedantic -Werror)
+
+# HTTP client example
+add_executable(beauty_http_client_example
+	pc/http_client_main.cpp
+)
+
+target_include_directories(beauty_http_client_example PRIVATE
+	${CMAKE_SOURCE_DIR}/examples/pc
+	${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(beauty_http_client_example PRIVATE asio::asio cjson ${CMAKE_PROJECT_NAME})
+
+target_compile_options(beauty_http_client_example PRIVATE -Wall -Wextra -Wpedantic -Werror)

--- a/examples/pc/http_client_main.cpp
+++ b/examples/pc/http_client_main.cpp
@@ -1,0 +1,87 @@
+// Example: a minimal HTTP client built on the Beauty library.
+//
+// It performs a single HTTP request against the given http:// URL and prints
+// the response status, headers and body. By default it issues a GET; pass a
+// method and (optionally) a request body to send something else.
+//
+// Usage:
+//   beauty_http_client_example http://127.0.0.1:8080/index.html
+//   beauty_http_client_example http://127.0.0.1:8080/api POST '{"k":"v"}'
+
+#include <iostream>
+#include <string>
+
+#include <asio.hpp>
+
+#include <beauty/header.hpp>
+#include <beauty/http_client.hpp>
+#include <beauty/i_http_client_handler.hpp>
+#include <beauty/response.hpp>
+
+using namespace beauty;
+
+// Handler that prints the response (or error) and then stops the io_context.
+class PrintingHandler : public IHttpClientHandler {
+   public:
+    explicit PrintingHandler(asio::io_context &ioc) : ioc_(ioc) {}
+
+    void onResponse(const Response &response) override {
+        std::cout << "HTTP/" << response.httpVersionMajor_ << "." << response.httpVersionMinor_
+                  << " " << response.statusCode_ << " " << response.statusMessage_ << "\n";
+        for (const auto &h : response.headers_) {
+            std::cout << h.name_ << ": " << h.value_ << "\n";
+        }
+        std::cout << "\n";
+        std::cout.write(response.body_.data(), static_cast<std::streamsize>(response.body_.size()));
+        std::cout << "\n";
+        ioc_.stop();
+    }
+
+    void onError(const std::string &error) override {
+        std::cerr << "[error] " << error << "\n";
+        ioc_.stop();
+    }
+
+   private:
+    asio::io_context &ioc_;
+};
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " http://host:port/path [METHOD] [body]\n";
+        return 1;
+    }
+
+    std::string url = argv[1];
+    std::string method = (argc >= 3) ? argv[2] : "GET";
+    std::string body = (argc >= 4) ? argv[3] : std::string();
+
+    try {
+        asio::io_context ioc;
+        PrintingHandler handler(ioc);
+
+        HttpClient::Config config;
+        config.maxResponseSize = 64 * 1024;
+        config.requestTimeout = std::chrono::seconds(10);
+
+        auto client = HttpClient::create(ioc, handler, config);
+
+        std::cout << method << " " << url << " ...\n";
+
+        // HttpClient::request() sets Host and Connection headers
+        // automatically. For POST/PUT with a body, use the post()/put()
+        // convenience methods which also set Content-Type.
+        if (method == "POST" || method == "PUT") {
+            client->request(method, url, {{"Content-Type", "application/octet-stream"}}, body);
+        } else {
+            client->request(method, url);
+        }
+
+        ioc.run();
+    } catch (std::exception &e) {
+        std::cerr << "exception: " << e.what() << "\n";
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/beauty/http_client.hpp
+++ b/src/beauty/http_client.hpp
@@ -35,6 +35,11 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
         // body, in bytes. Responses whose body exceeds this are rejected.
         size_t maxResponseSize = 1024;
 
+        // Maximum size of a request body, in bytes. Requests with a body
+        // larger than this are rejected with an asynchronous onError.
+        // Defaults to maxResponseSize.
+        size_t maxRequestBodySize = 0;
+
         // Maximum time to wait for a request to complete (resolve + connect +
         // send + receive). 0 disables the timeout.
         std::chrono::milliseconds requestTimeout = std::chrono::milliseconds(5000);
@@ -110,14 +115,14 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
 
     // Fixed maximum size buffers.
     std::vector<char> recvBuffer_;  // Socket reads / response parsing input
-    std::vector<char> sendBuffer_;  // Outgoing request bytes
+    std::vector<char> sendBuffer_;  // Outgoing request body (bounded by maxRequestBodySize)
     std::vector<char> bodyBuffer_;  // Response body (referenced by response_)
 
     UrlParser url_;
     std::string host_;
     std::string port_;
     std::string method_;
-    std::string headerBlock_;  // Fully rendered request head + body for the current request
+    std::string headerBlock_;  // Rendered request-line + headers (no body)
 
     Response response_;
     ResponseParser responseParser_;

--- a/src/beauty/http_client.hpp
+++ b/src/beauty/http_client.hpp
@@ -1,0 +1,145 @@
+#pragma once
+// included first
+#include "beauty/environment.hpp"
+
+#include <asio.hpp>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "beauty/header.hpp"
+#include "beauty/i_http_client_handler.hpp"
+#include "beauty/response.hpp"
+#include "beauty/response_parser.hpp"
+#include "beauty/url_parser.hpp"
+
+namespace beauty {
+
+// An asynchronous HTTP/1.1 client that runs on a (shared) asio::io_context,
+// following the same philosophy as the Beauty server and WebSocket client:
+// fixed maximum size receive/send buffers, no per-message dynamic allocation of
+// unbounded size, and fully asynchronous, callback based operation.
+//
+// The client is intended to be owned through a std::shared_ptr so that its
+// lifetime is guaranteed for the duration of outstanding asynchronous
+// operations. Use HttpClient::create() to construct one.
+//
+// Only a single request may be in flight at a time. Issue the next request from
+// within the onResponse/onError callback (or after it returns).
+class HttpClient : public std::enable_shared_from_this<HttpClient> {
+   public:
+    struct Config {
+        // Maximum size of the receive buffer and of the accumulated response
+        // body, in bytes. Responses whose body exceeds this are rejected.
+        size_t maxResponseSize = 1024;
+
+        // Maximum time to wait for a request to complete (resolve + connect +
+        // send + receive). 0 disables the timeout.
+        std::chrono::milliseconds requestTimeout = std::chrono::milliseconds(5000);
+
+        // Reuse the underlying TCP connection for subsequent requests to the
+        // same host and port when the server allows it (keep-alive).
+        bool keepAlive = true;
+    };
+
+    HttpClient(const HttpClient &) = delete;
+    HttpClient &operator=(const HttpClient &) = delete;
+
+    static std::shared_ptr<HttpClient> create(asio::io_context &ioContext,
+                                              IHttpClientHandler &handler,
+                                              const Config &config);
+
+    static std::shared_ptr<HttpClient> create(asio::io_context &ioContext,
+                                              IHttpClientHandler &handler);
+
+    ~HttpClient() = default;
+
+    // Perform an HTTP request against the given http:// URL. Returns false (and
+    // does nothing) if a request is already in progress. On completion either
+    // onResponse or onError is invoked exactly once.
+    bool request(const std::string &method,
+                 const std::string &url,
+                 const std::vector<Header> &headers = std::vector<Header>(),
+                 const std::string &body = std::string());
+
+    // Convenience wrappers around request().
+    bool get(const std::string &url,
+             const std::vector<Header> &headers = std::vector<Header>());
+    bool head(const std::string &url,
+              const std::vector<Header> &headers = std::vector<Header>());
+    bool del(const std::string &url,
+             const std::vector<Header> &headers = std::vector<Header>());
+    bool post(const std::string &url,
+              const std::string &contentType,
+              const std::string &body,
+              const std::vector<Header> &headers = std::vector<Header>());
+    bool put(const std::string &url,
+             const std::string &contentType,
+             const std::string &body,
+             const std::vector<Header> &headers = std::vector<Header>());
+
+    // Close the underlying connection (if any). Does not fire any callback.
+    void close();
+
+    // True while a request is in flight.
+    bool busy() const {
+        return requestInProgress_;
+    }
+
+   private:
+    HttpClient(asio::io_context &ioContext, IHttpClientHandler &handler, const Config &config);
+
+    void startRequest();
+    void doResolve();
+    void doConnect(const asio::ip::tcp::resolver::results_type &endpoints);
+    void doWriteRequest();
+    void doReadResponse();
+    void startTimeoutTimer();
+
+    void deliverResponse();
+    void reportError(const std::string &error);
+    void closeSocket();
+    bool sameTarget(const std::string &host, const std::string &port) const;
+
+    asio::io_context &ioContext_;
+    asio::ip::tcp::resolver resolver_;
+    asio::ip::tcp::socket socket_;
+    asio::steady_timer timeoutTimer_;
+
+    IHttpClientHandler &handler_;
+    Config config_;
+
+    // Fixed maximum size buffers.
+    std::vector<char> recvBuffer_;  // Socket reads / response parsing input
+    std::vector<char> sendBuffer_;  // Outgoing request bytes
+    std::vector<char> bodyBuffer_;  // Response body (referenced by response_)
+
+    UrlParser url_;
+    std::string host_;
+    std::string port_;
+    std::string method_;
+    std::string headerBlock_;  // Fully rendered request head + body for the current request
+
+    Response response_;
+    ResponseParser responseParser_;
+
+    bool requestInProgress_ = false;
+    bool connected_ = false;
+    std::string connectedHost_;
+    std::string connectedPort_;
+};
+
+inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
+                                                     IHttpClientHandler &handler,
+                                                     const Config &config) {
+    return std::shared_ptr<HttpClient>(new HttpClient(ioContext, handler, config));
+}
+
+inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
+                                                     IHttpClientHandler &handler) {
+    return std::shared_ptr<HttpClient>(new HttpClient(ioContext, handler, Config()));
+}
+
+}  // namespace beauty

--- a/src/beauty/http_client.hpp
+++ b/src/beauty/http_client.hpp
@@ -65,12 +65,9 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
                  const std::string &body = std::string());
 
     // Convenience wrappers around request().
-    bool get(const std::string &url,
-             const std::vector<Header> &headers = std::vector<Header>());
-    bool head(const std::string &url,
-              const std::vector<Header> &headers = std::vector<Header>());
-    bool del(const std::string &url,
-             const std::vector<Header> &headers = std::vector<Header>());
+    bool get(const std::string &url, const std::vector<Header> &headers = std::vector<Header>());
+    bool head(const std::string &url, const std::vector<Header> &headers = std::vector<Header>());
+    bool del(const std::string &url, const std::vector<Header> &headers = std::vector<Header>());
     bool post(const std::string &url,
               const std::string &contentType,
               const std::string &body,
@@ -132,13 +129,13 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
 };
 
 inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
-                                                     IHttpClientHandler &handler,
-                                                     const Config &config) {
+                                                      IHttpClientHandler &handler,
+                                                      const Config &config) {
     return std::shared_ptr<HttpClient>(new HttpClient(ioContext, handler, config));
 }
 
 inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
-                                                     IHttpClientHandler &handler) {
+                                                      IHttpClientHandler &handler) {
     return std::shared_ptr<HttpClient>(new HttpClient(ioContext, handler, Config()));
 }
 

--- a/src/beauty/i_http_client_handler.hpp
+++ b/src/beauty/i_http_client_handler.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+namespace beauty {
+
+struct Response;
+
+// Callback interface implemented by the application to receive HTTP client
+// events. All callbacks are invoked on the thread that runs the asio
+// io_context, mirroring the WebSocket client interface.
+class IHttpClientHandler {
+   public:
+    virtual ~IHttpClientHandler() = default;
+
+    // Called once a complete HTTP response has been received. The response and
+    // its body buffer are only valid for the duration of this callback.
+    virtual void onResponse(const Response &response) = 0;
+
+    // Called when an error occurs during resolve, connect, sending the request
+    // or receiving the response (including timeouts and oversized responses).
+    virtual void onError(const std::string &error) = 0;
+};
+
+}  // namespace beauty

--- a/src/beauty/parse_common.hpp
+++ b/src/beauty/parse_common.hpp
@@ -51,6 +51,26 @@ inline bool isDigit(int c) {
     return c >= '0' && c <= '9';
 }
 
+// Check if a byte is a hexadecimal digit.
+inline bool isHexDigit(int c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+// Convert a hexadecimal digit to its numeric value. Returns 0 for non-hex input
+// (callers are expected to validate with isHexDigit first).
+inline int hexValue(int c) {
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    return 0;
+}
+
 // Safely parse a non-negative decimal integer from a C string.
 // Returns true and writes the value to *out on success.
 // Returns false (and leaves *out unchanged) when the string is empty, contains

--- a/src/beauty/response_parser.hpp
+++ b/src/beauty/response_parser.hpp
@@ -17,6 +17,10 @@ class ResponseParser {
     // Reset to initial parser state.
     void reset();
 
+    // Set an upper bound on the accumulated body size. If the body grows beyond
+    // this, parse() returns too_large. Defaults to no limit.
+    void setMaxBodySize(size_t maxBodySize);
+
     // Result of parse.
     enum result_type {
         good_complete,        // A complete response (status line + headers + body) parsed
@@ -24,6 +28,7 @@ class ResponseParser {
         switching_protocols,  // 101 response - headers complete, no body (WebSocket upgrade)
         bad,                  // Malformed response
         version_not_supported,
+        too_large,  // Body exceeded the configured maximum size
         indeterminate
     };
 
@@ -31,6 +36,11 @@ class ResponseParser {
     // parsed, bad on invalid data, good_part when more data is required and
     // switching_protocols when a 101 response was received.
     result_type parse(Response &res, std::vector<char> &content);
+
+    // Called by the client when the peer closed the connection with no further
+    // data. Returns good_complete if the body was delimited by connection close
+    // (no Content-Length, not chunked), otherwise bad (truncated response).
+    result_type finish(Response &res);
 
    private:
     // Handle the next character of input.
@@ -63,10 +73,25 @@ class ResponseParser {
         expecting_newline_2,
         expecting_newline_3,
         body,
+        // Chunked transfer-encoding states.
+        chunk_size,
+        chunk_extension,
+        chunk_size_newline,
+        chunk_data,
+        chunk_data_cr,
+        chunk_data_newline,
+        chunk_trailer_start,
+        chunk_trailer_line,
+        chunk_trailer_line_newline,
+        chunk_trailer_end_newline,
     } state_;
 
     std::size_t contentLength_ = std::numeric_limits<size_t>::max();
     bool noBodyExpected_ = false;
+    bool isChunked_ = false;
+    bool interimResponse_ = false;
+    std::size_t chunkRemaining_ = 0;
+    std::size_t maxBodySize_ = std::numeric_limits<size_t>::max();
 };
 
 }  // namespace beauty

--- a/src/beauty/response_parser.hpp
+++ b/src/beauty/response_parser.hpp
@@ -23,7 +23,7 @@ class ResponseParser {
 
     // Tell the parser that the request method was HEAD. HEAD responses never
     // carry a body regardless of Content-Length. Must be called after reset()
-    // and before parse(). Not cleared by reset() (same lifetime as maxBodySize).
+    // and before parse().
     void setHeadRequest(bool head);
 
     // Result of parse.

--- a/src/beauty/response_parser.hpp
+++ b/src/beauty/response_parser.hpp
@@ -21,6 +21,11 @@ class ResponseParser {
     // this, parse() returns too_large. Defaults to no limit.
     void setMaxBodySize(size_t maxBodySize);
 
+    // Tell the parser that the request method was HEAD. HEAD responses never
+    // carry a body regardless of Content-Length. Must be called after reset()
+    // and before parse(). Not cleared by reset() (same lifetime as maxBodySize).
+    void setHeadRequest(bool head);
+
     // Result of parse.
     enum result_type {
         good_complete,        // A complete response (status line + headers + body) parsed
@@ -93,6 +98,7 @@ class ResponseParser {
     bool chunkSizeDigitSeen_ = false;
     std::size_t chunkRemaining_ = 0;
     std::size_t maxBodySize_ = std::numeric_limits<size_t>::max();
+    bool headRequest_ = false;
 };
 
 }  // namespace beauty

--- a/src/beauty/response_parser.hpp
+++ b/src/beauty/response_parser.hpp
@@ -90,6 +90,7 @@ class ResponseParser {
     bool noBodyExpected_ = false;
     bool isChunked_ = false;
     bool interimResponse_ = false;
+    bool chunkSizeDigitSeen_ = false;
     std::size_t chunkRemaining_ = 0;
     std::size_t maxBodySize_ = std::numeric_limits<size_t>::max();
 };

--- a/src/beauty/url_parser.hpp
+++ b/src/beauty/url_parser.hpp
@@ -260,10 +260,15 @@ class UrlParser {
             }
         }
 
-        assert(portOrPassword.empty());
-
         if (!usernameOrHostname.empty()) {
             url_.hostname_ = usernameOrHostname;
+        }
+        if (!portOrPassword.empty()) {
+            url_.port_ = portOrPassword;
+            if (!parseUint16(url_.port_.c_str(), url_.integerPort_)) {
+                valid_ = false;
+                url_ = Url();
+            }
         }
     }
 

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -15,7 +15,12 @@ HttpClient::HttpClient(asio::io_context &ioContext,
       config_(config),
       response_(bodyBuffer_),
       responseParser_() {
+    // Default maxRequestBodySize to maxResponseSize when left at 0.
+    if (config_.maxRequestBodySize == 0) {
+        config_.maxRequestBodySize = config_.maxResponseSize;
+    }
     recvBuffer_.reserve(config_.maxResponseSize);
+    sendBuffer_.reserve(config_.maxRequestBodySize);
     bodyBuffer_.reserve(config_.maxResponseSize);
     responseParser_.setMaxBodySize(config_.maxResponseSize);
 }
@@ -47,6 +52,15 @@ bool HttpClient::request(const std::string &method,
     port_ = std::to_string(url_.httpPort());
     method_ = method;
 
+    // Reject bodies that exceed the configured cap.
+    if (body.size() > config_.maxRequestBodySize) {
+        requestInProgress_ = true;
+        auto self(shared_from_this());
+        asio::post(ioContext_,
+                   [this, self]() { reportError("Request body exceeds maximum size"); });
+        return true;
+    }
+
     std::string target = url_.path();
     if (target.empty()) {
         target = "/";
@@ -55,9 +69,9 @@ bool HttpClient::request(const std::string &method,
         target += "?" + url_.query();
     }
 
-    // Render the request head (and body) into a single buffer.
+    // Build only headers into headerBlock_ (bounded, small).
     std::string req;
-    req.reserve(128 + body.size());
+    req.reserve(256);
     req += method_ + " " + target + " HTTP/1.1\r\n";
     req += "Host: " + host_ + ":" + port_ + "\r\n";
     req += std::string("Connection: ") + (config_.keepAlive ? "keep-alive" : "close") + "\r\n";
@@ -68,9 +82,11 @@ bool HttpClient::request(const std::string &method,
         req += "Content-Length: " + std::to_string(body.size()) + "\r\n";
     }
     req += "\r\n";
-    req += body;
 
     headerBlock_ = std::move(req);
+
+    // Store body separately in the fixed-size send buffer.
+    sendBuffer_.assign(body.begin(), body.end());
 
     startRequest();
     return true;
@@ -175,18 +191,21 @@ void HttpClient::doConnect(const asio::ip::tcp::resolver::results_type &endpoint
 }
 
 void HttpClient::doWriteRequest() {
-    sendBuffer_.assign(headerBlock_.begin(), headerBlock_.end());
+    // Scatter-gather write: send headers and body without concatenating.
+    std::array<asio::const_buffer, 2> buffers = {{
+        asio::buffer(headerBlock_),
+        asio::buffer(sendBuffer_),
+    }};
     auto self(shared_from_this());
-    asio::async_write(
-        socket_, asio::buffer(sendBuffer_), [this, self](const std::error_code &ec, std::size_t) {
-            if (ec) {
-                // A keep-alive connection may have been closed by the server
-                // between requests; surface it as an error.
-                reportError("Write failed: " + ec.message());
-                return;
-            }
-            doReadResponse();
-        });
+    asio::async_write(socket_, buffers, [this, self](const std::error_code &ec, std::size_t) {
+        if (ec) {
+            // A keep-alive connection may have been closed by the server
+            // between requests; surface it as an error.
+            reportError("Write failed: " + ec.message());
+            return;
+        }
+        doReadResponse();
+    });
 }
 
 void HttpClient::doReadResponse() {

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -109,6 +109,7 @@ bool HttpClient::put(const std::string &url,
 void HttpClient::startRequest() {
     requestInProgress_ = true;
     responseParser_.reset();
+    responseParser_.setHeadRequest(method_ == "HEAD");
     response_.reset();
     recvBuffer_.clear();
     bodyBuffer_.clear();

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -1,5 +1,6 @@
-#include "beauty/http_client.hpp"
+#include <array>
 
+#include "beauty/http_client.hpp"
 #include "beauty/parse_common.hpp"
 
 namespace beauty {

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -259,7 +259,20 @@ void HttpClient::deliverResponse() {
         closeSocket();
     }
 
-    handler_.onResponse(response_);
+    // Snapshot the response into stack-locals so that a re-entrant
+    // request() from within onResponse does not mutate the object the
+    // handler is still inspecting.
+    std::vector<char> deliveredBody;
+    deliveredBody.swap(bodyBuffer_);
+    Response snapshot(deliveredBody);
+    snapshot.httpVersionMajor_ = response_.httpVersionMajor_;
+    snapshot.httpVersionMinor_ = response_.httpVersionMinor_;
+    snapshot.statusCode_ = response_.statusCode_;
+    snapshot.statusMessage_.swap(response_.statusMessage_);
+    snapshot.headers_.swap(response_.headers_);
+    snapshot.keepAlive_ = response_.keepAlive_;
+
+    handler_.onResponse(snapshot);
 }
 
 void HttpClient::reportError(const std::string &error) {

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -143,6 +143,9 @@ void HttpClient::doResolve() {
                             port_,
                             [this, self](const std::error_code &ec,
                                          const asio::ip::tcp::resolver::results_type &endpoints) {
+                                if (!requestInProgress_) {
+                                    return;
+                                }
                                 if (ec) {
                                     reportError("Resolve failed: " + ec.message());
                                     return;
@@ -156,6 +159,9 @@ void HttpClient::doConnect(const asio::ip::tcp::resolver::results_type &endpoint
     asio::async_connect(socket_,
                         endpoints,
                         [this, self](const std::error_code &ec, const asio::ip::tcp::endpoint &) {
+                            if (!requestInProgress_) {
+                                return;
+                            }
                             if (ec) {
                                 reportError("Connect failed: " + ec.message());
                                 return;
@@ -247,11 +253,15 @@ void HttpClient::reportError(const std::string &error) {
 }
 
 void HttpClient::close() {
+    timeoutTimer_.cancel();
+    resolver_.cancel();
+    requestInProgress_ = false;
     closeSocket();
 }
 
 void HttpClient::closeSocket() {
     std::error_code ignore;
+    resolver_.cancel();
     socket_.close(ignore);
     connected_ = false;
     connectedHost_.clear();

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -1,0 +1,265 @@
+#include "beauty/http_client.hpp"
+
+#include "beauty/parse_common.hpp"
+
+namespace beauty {
+
+HttpClient::HttpClient(asio::io_context &ioContext,
+                       IHttpClientHandler &handler,
+                       const Config &config)
+    : ioContext_(ioContext),
+      resolver_(ioContext),
+      socket_(ioContext),
+      timeoutTimer_(ioContext),
+      handler_(handler),
+      config_(config),
+      response_(bodyBuffer_),
+      responseParser_() {
+    recvBuffer_.reserve(config_.maxResponseSize);
+    bodyBuffer_.reserve(config_.maxResponseSize);
+    responseParser_.setMaxBodySize(config_.maxResponseSize);
+}
+
+bool HttpClient::request(const std::string &method,
+                         const std::string &url,
+                         const std::vector<Header> &headers,
+                         const std::string &body) {
+    if (requestInProgress_) {
+        return false;
+    }
+
+    // Assume http:// when no scheme is provided.
+    std::string effectiveUrl = url;
+    if (url.find("://") == std::string::npos) {
+        effectiveUrl = "http://" + url;
+    }
+
+    if (!url_.parse(effectiveUrl) || url_.hostname().empty()) {
+        // Deliver the error asynchronously so the handler is never invoked
+        // re-entrantly from request().
+        requestInProgress_ = true;
+        auto self(shared_from_this());
+        asio::post(ioContext_, [this, self]() { reportError("Invalid URL"); });
+        return true;
+    }
+
+    host_ = url_.hostname();
+    port_ = std::to_string(url_.httpPort());
+    method_ = method;
+
+    std::string target = url_.path();
+    if (target.empty()) {
+        target = "/";
+    }
+    if (!url_.query().empty()) {
+        target += "?" + url_.query();
+    }
+
+    // Render the request head (and body) into a single buffer.
+    std::string req;
+    req.reserve(128 + body.size());
+    req += method_ + " " + target + " HTTP/1.1\r\n";
+    req += "Host: " + host_ + ":" + port_ + "\r\n";
+    req += std::string("Connection: ") + (config_.keepAlive ? "keep-alive" : "close") + "\r\n";
+    for (const Header &h : headers) {
+        req += h.name_ + ": " + h.value_ + "\r\n";
+    }
+    if (!body.empty()) {
+        req += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+    }
+    req += "\r\n";
+    req += body;
+
+    headerBlock_ = std::move(req);
+
+    startRequest();
+    return true;
+}
+
+bool HttpClient::get(const std::string &url, const std::vector<Header> &headers) {
+    return request("GET", url, headers, std::string());
+}
+
+bool HttpClient::head(const std::string &url, const std::vector<Header> &headers) {
+    return request("HEAD", url, headers, std::string());
+}
+
+bool HttpClient::del(const std::string &url, const std::vector<Header> &headers) {
+    return request("DELETE", url, headers, std::string());
+}
+
+bool HttpClient::post(const std::string &url,
+                      const std::string &contentType,
+                      const std::string &body,
+                      const std::vector<Header> &headers) {
+    std::vector<Header> all = headers;
+    all.push_back(Header{"Content-Type", contentType});
+    return request("POST", url, all, body);
+}
+
+bool HttpClient::put(const std::string &url,
+                     const std::string &contentType,
+                     const std::string &body,
+                     const std::vector<Header> &headers) {
+    std::vector<Header> all = headers;
+    all.push_back(Header{"Content-Type", contentType});
+    return request("PUT", url, all, body);
+}
+
+void HttpClient::startRequest() {
+    requestInProgress_ = true;
+    responseParser_.reset();
+    response_.reset();
+    recvBuffer_.clear();
+    bodyBuffer_.clear();
+
+    startTimeoutTimer();
+
+    // Reuse an existing keep-alive connection to the same target if possible.
+    if (connected_ && socket_.is_open() && sameTarget(host_, port_)) {
+        doWriteRequest();
+    } else {
+        closeSocket();
+        doResolve();
+    }
+}
+
+void HttpClient::startTimeoutTimer() {
+    if (config_.requestTimeout.count() == 0) {
+        return;
+    }
+    auto self(shared_from_this());
+    timeoutTimer_.expires_after(config_.requestTimeout);
+    timeoutTimer_.async_wait([this, self](const std::error_code &ec) {
+        if (!ec && requestInProgress_) {
+            reportError("Request timed out");
+        }
+    });
+}
+
+void HttpClient::doResolve() {
+    auto self(shared_from_this());
+    resolver_.async_resolve(host_,
+                            port_,
+                            [this, self](const std::error_code &ec,
+                                         const asio::ip::tcp::resolver::results_type &endpoints) {
+                                if (ec) {
+                                    reportError("Resolve failed: " + ec.message());
+                                    return;
+                                }
+                                doConnect(endpoints);
+                            });
+}
+
+void HttpClient::doConnect(const asio::ip::tcp::resolver::results_type &endpoints) {
+    auto self(shared_from_this());
+    asio::async_connect(socket_,
+                        endpoints,
+                        [this, self](const std::error_code &ec, const asio::ip::tcp::endpoint &) {
+                            if (ec) {
+                                reportError("Connect failed: " + ec.message());
+                                return;
+                            }
+                            connected_ = true;
+                            connectedHost_ = host_;
+                            connectedPort_ = port_;
+                            doWriteRequest();
+                        });
+}
+
+void HttpClient::doWriteRequest() {
+    sendBuffer_.assign(headerBlock_.begin(), headerBlock_.end());
+    auto self(shared_from_this());
+    asio::async_write(
+        socket_, asio::buffer(sendBuffer_), [this, self](const std::error_code &ec, std::size_t) {
+            if (ec) {
+                // A keep-alive connection may have been closed by the server
+                // between requests; surface it as an error.
+                reportError("Write failed: " + ec.message());
+                return;
+            }
+            doReadResponse();
+        });
+}
+
+void HttpClient::doReadResponse() {
+    auto self(shared_from_this());
+    recvBuffer_.resize(config_.maxResponseSize);
+    socket_.async_read_some(
+        asio::buffer(recvBuffer_),
+        [this, self](const std::error_code &ec, std::size_t bytesTransferred) {
+            if (ec) {
+                if (ec == asio::error::eof || ec == asio::error::connection_reset) {
+                    // The server closed the connection. If the body was
+                    // delimited by connection close this completes the response.
+                    connected_ = false;
+                    ResponseParser::result_type result = responseParser_.finish(response_);
+                    if (result == ResponseParser::good_complete) {
+                        deliverResponse();
+                    } else {
+                        reportError("Connection closed before response completed");
+                    }
+                } else {
+                    reportError("Read failed: " + ec.message());
+                }
+                return;
+            }
+
+            recvBuffer_.resize(bytesTransferred);
+            ResponseParser::result_type result = responseParser_.parse(response_, recvBuffer_);
+
+            if (result == ResponseParser::good_complete) {
+                deliverResponse();
+            } else if (result == ResponseParser::good_part) {
+                doReadResponse();
+            } else if (result == ResponseParser::too_large) {
+                reportError("Response body exceeds maximum size");
+            } else if (result == ResponseParser::version_not_supported) {
+                reportError("Unsupported HTTP version in response");
+            } else if (result == ResponseParser::switching_protocols) {
+                reportError("Unexpected 101 Switching Protocols response");
+            } else {
+                reportError("Malformed HTTP response");
+            }
+        });
+}
+
+void HttpClient::deliverResponse() {
+    timeoutTimer_.cancel();
+    requestInProgress_ = false;
+
+    bool keep = config_.keepAlive && response_.keepAlive_ && connected_;
+    if (!keep) {
+        closeSocket();
+    }
+
+    handler_.onResponse(response_);
+}
+
+void HttpClient::reportError(const std::string &error) {
+    if (!requestInProgress_) {
+        return;
+    }
+    timeoutTimer_.cancel();
+    requestInProgress_ = false;
+    closeSocket();
+    handler_.onError(error);
+}
+
+void HttpClient::close() {
+    closeSocket();
+}
+
+void HttpClient::closeSocket() {
+    std::error_code ignore;
+    socket_.close(ignore);
+    connected_ = false;
+    connectedHost_.clear();
+    connectedPort_.clear();
+}
+
+bool HttpClient::sameTarget(const std::string &host, const std::string &port) const {
+    return connectedHost_ == host && connectedPort_ == port;
+}
+
+}  // namespace beauty

--- a/src/response_parser.cpp
+++ b/src/response_parser.cpp
@@ -24,6 +24,10 @@ void ResponseParser::setMaxBodySize(size_t maxBodySize) {
     maxBodySize_ = maxBodySize;
 }
 
+void ResponseParser::setHeadRequest(bool head) {
+    headRequest_ = head;
+}
+
 ResponseParser::result_type ResponseParser::finish(Response &res) {
     // The peer closed the connection. A response with neither Content-Length
     // nor chunked encoding is delimited by the close itself, so whatever body
@@ -415,6 +419,12 @@ ResponseParser::result_type ResponseParser::checkResponseAfterAllHeaders(Respons
 
     // 204 No Content and 304 Not Modified never carry a body.
     if (res.statusCode_ == 204 || res.statusCode_ == 304) {
+        noBodyExpected_ = true;
+        return indeterminate;
+    }
+
+    // HEAD responses never carry a body regardless of Content-Length.
+    if (headRequest_) {
         noBodyExpected_ = true;
         return indeterminate;
     }

--- a/src/response_parser.cpp
+++ b/src/response_parser.cpp
@@ -14,6 +14,25 @@ void ResponseParser::reset() {
     state_ = http_version_h;
     contentLength_ = std::numeric_limits<size_t>::max();
     noBodyExpected_ = false;
+    isChunked_ = false;
+    interimResponse_ = false;
+    chunkRemaining_ = 0;
+}
+
+void ResponseParser::setMaxBodySize(size_t maxBodySize) {
+    maxBodySize_ = maxBodySize;
+}
+
+ResponseParser::result_type ResponseParser::finish(Response &res) {
+    // The peer closed the connection. A response with neither Content-Length
+    // nor chunked encoding is delimited by the close itself, so whatever body
+    // bytes we accumulated form the complete body.
+    if (state_ == body && contentLength_ == std::numeric_limits<size_t>::max() && !isChunked_) {
+        return good_complete;
+    }
+    // Anything else means the connection closed mid-response.
+    (void)res;
+    return bad;
 }
 
 ResponseParser::result_type ResponseParser::parse(Response &res, std::vector<char> &content) {
@@ -237,8 +256,24 @@ ResponseParser::result_type ResponseParser::consume(Response &res,
             if (res2 != indeterminate) {
                 return res2;
             }
+            if (interimResponse_) {
+                // A 1xx interim response (other than 101) is not the final
+                // response. Discard it and continue parsing the response that
+                // follows on the same connection.
+                res.reset();
+                reset();
+                return indeterminate;
+            }
             // start filling up body data
             res.body_.clear();
+            if (noBodyExpected_) {
+                return good_complete;
+            }
+            if (isChunked_) {
+                chunkRemaining_ = 0;
+                state_ = chunk_size;
+                return indeterminate;
+            }
             if (contentLength_ == 0) {
                 return good_complete;
             }
@@ -246,6 +281,9 @@ ResponseParser::result_type ResponseParser::consume(Response &res,
             return indeterminate;
         }
         case body:
+            if (res.body_.size() >= maxBodySize_) {
+                return too_large;
+            }
             res.body_.push_back(input);
             if (contentLength_ != std::numeric_limits<size_t>::max()) {
                 if (res.body_.size() >= contentLength_) {
@@ -253,6 +291,78 @@ ResponseParser::result_type ResponseParser::consume(Response &res,
                 }
             }
             return indeterminate;
+        case chunk_size:
+            if (isHexDigit(input)) {
+                chunkRemaining_ = chunkRemaining_ * 16 + hexValue(input);
+            } else if (input == ';') {
+                state_ = chunk_extension;
+            } else if (input == '\r') {
+                state_ = chunk_size_newline;
+            } else {
+                return bad;
+            }
+            return indeterminate;
+        case chunk_extension:
+            // Chunk extensions are ignored.
+            if (input == '\r') {
+                state_ = chunk_size_newline;
+            }
+            return indeterminate;
+        case chunk_size_newline:
+            if (input != '\n') {
+                return bad;
+            }
+            if (chunkRemaining_ == 0) {
+                // Last chunk - trailers (if any) follow.
+                state_ = chunk_trailer_start;
+            } else {
+                state_ = chunk_data;
+            }
+            return indeterminate;
+        case chunk_data:
+            if (res.body_.size() >= maxBodySize_) {
+                return too_large;
+            }
+            res.body_.push_back(input);
+            if (--chunkRemaining_ == 0) {
+                state_ = chunk_data_cr;
+            }
+            return indeterminate;
+        case chunk_data_cr:
+            if (input != '\r') {
+                return bad;
+            }
+            state_ = chunk_data_newline;
+            return indeterminate;
+        case chunk_data_newline:
+            if (input != '\n') {
+                return bad;
+            }
+            state_ = chunk_size;
+            return indeterminate;
+        case chunk_trailer_start:
+            if (input == '\r') {
+                state_ = chunk_trailer_end_newline;
+            } else {
+                state_ = chunk_trailer_line;
+            }
+            return indeterminate;
+        case chunk_trailer_line:
+            if (input == '\r') {
+                state_ = chunk_trailer_line_newline;
+            }
+            return indeterminate;
+        case chunk_trailer_line_newline:
+            if (input != '\n') {
+                return bad;
+            }
+            state_ = chunk_trailer_start;
+            return indeterminate;
+        case chunk_trailer_end_newline:
+            if (input != '\n') {
+                return bad;
+            }
+            return good_complete;
         default:
             return bad;
     }
@@ -281,15 +391,26 @@ void ResponseParser::storeHeaderValueIfNeeded(Response &res) {
 }
 
 ResponseParser::result_type ResponseParser::checkResponseAfterAllHeaders(Response &res) {
-    // 1xx informational, 204 No Content and 304 Not Modified never carry a body.
-    if ((res.statusCode_ >= 100 && res.statusCode_ < 200) || res.statusCode_ == 204 ||
-        res.statusCode_ == 304) {
-        contentLength_ = 0;
-        noBodyExpected_ = true;
-    }
-
     if (res.statusCode_ == 101) {
         return switching_protocols;
+    }
+
+    // 1xx informational responses (other than 101) are interim: the real
+    // response follows on the same connection and must be parsed next.
+    if (res.statusCode_ >= 100 && res.statusCode_ < 200) {
+        interimResponse_ = true;
+        return indeterminate;
+    }
+
+    // 204 No Content and 304 Not Modified never carry a body.
+    if (res.statusCode_ == 204 || res.statusCode_ == 304) {
+        noBodyExpected_ = true;
+        return indeterminate;
+    }
+
+    // A chunked response is self-delimiting regardless of Content-Length.
+    if (res.isChunked_) {
+        isChunked_ = true;
     }
 
     return indeterminate;

--- a/src/response_parser.cpp
+++ b/src/response_parser.cpp
@@ -16,6 +16,7 @@ void ResponseParser::reset() {
     noBodyExpected_ = false;
     isChunked_ = false;
     interimResponse_ = false;
+    chunkSizeDigitSeen_ = false;
     chunkRemaining_ = 0;
 }
 
@@ -28,6 +29,7 @@ ResponseParser::result_type ResponseParser::finish(Response &res) {
     // nor chunked encoding is delimited by the close itself, so whatever body
     // bytes we accumulated form the complete body.
     if (state_ == body && contentLength_ == std::numeric_limits<size_t>::max() && !isChunked_) {
+        res.keepAlive_ = false;
         return good_complete;
     }
     // Anything else means the connection closed mid-response.
@@ -293,10 +295,17 @@ ResponseParser::result_type ResponseParser::consume(Response &res,
             return indeterminate;
         case chunk_size:
             if (isHexDigit(input)) {
+                chunkSizeDigitSeen_ = true;
                 chunkRemaining_ = chunkRemaining_ * 16 + hexValue(input);
             } else if (input == ';') {
+                if (!chunkSizeDigitSeen_) {
+                    return bad;
+                }
                 state_ = chunk_extension;
             } else if (input == '\r') {
+                if (!chunkSizeDigitSeen_) {
+                    return bad;
+                }
                 state_ = chunk_size_newline;
             } else {
                 return bad;
@@ -338,6 +347,8 @@ ResponseParser::result_type ResponseParser::consume(Response &res,
             if (input != '\n') {
                 return bad;
             }
+            chunkRemaining_ = 0;
+            chunkSizeDigitSeen_ = false;
             state_ = chunk_size;
             return indeterminate;
         case chunk_trailer_start:

--- a/src/response_parser.cpp
+++ b/src/response_parser.cpp
@@ -393,7 +393,11 @@ void ResponseParser::storeHeaderValueIfNeeded(Response &res) {
             contentLength_ = actualContentLength;
         }
     } else if (strcasecmp(h.name_.c_str(), "Transfer-Encoding") == 0) {
-        if (strcasecmp(h.value_.c_str(), "chunked") == 0) {
+        // Handle both bare "chunked" and lists like "gzip, chunked".
+        // Per HTTP/1.1, chunked is always the last transfer-coding when present.
+        std::string lower = h.value_;
+        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+        if (lower.find("chunked") != std::string::npos) {
             res.isChunked_ = true;
         }
     } else if (strcasecmp(h.name_.c_str(), "Connection") == 0) {

--- a/src/response_parser.cpp
+++ b/src/response_parser.cpp
@@ -18,6 +18,7 @@ void ResponseParser::reset() {
     interimResponse_ = false;
     chunkSizeDigitSeen_ = false;
     chunkRemaining_ = 0;
+    headRequest_ = false;
 }
 
 void ResponseParser::setMaxBodySize(size_t maxBodySize) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(${PROJECT_NAME}
 	random_interface_test.cpp
 	response_parser_test.cpp
 	ws_client_test.cpp
+	http_client_test.cpp
 	${CMAKE_SOURCE_DIR}/examples/pc/file_io.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/utils/mock_file_io.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/utils/mock_request_handler.cpp

--- a/test/http_client_test.cpp
+++ b/test/http_client_test.cpp
@@ -123,6 +123,18 @@ TEST_CASE("http client request/response", "[http_client]") {
         REQUIRE(handler.lastStatus_ == 404);
     }
 
+    SECTION("should HEAD a resource and get no body") {
+        TestHttpHandler handler(ioc);
+        auto client = HttpClient::create(ioc, handler);
+        REQUIRE(client->head(base + "/hello"));
+        ioc.run();
+
+        REQUIRE(handler.error_.empty());
+        REQUIRE(handler.responseCount_ == 1);
+        REQUIRE(handler.lastStatus_ == 200);
+        REQUIRE(handler.lastBody_.empty());
+    }
+
     SECTION("should POST a body and receive it echoed back") {
         TestHttpHandler handler(ioc);
         auto client = HttpClient::create(ioc, handler);

--- a/test/http_client_test.cpp
+++ b/test/http_client_test.cpp
@@ -209,4 +209,15 @@ TEST_CASE("http client error handling", "[http_client]") {
         ioc.run();
         REQUIRE_FALSE(handler.error_.empty());
     }
+
+    SECTION("should reject a request body that exceeds maxRequestBodySize") {
+        TestHttpHandler handler(ioc);
+        HttpClient::Config config;
+        config.maxRequestBodySize = 16;
+        auto client = HttpClient::create(ioc, handler, config);
+        std::string bigBody(17, 'x');
+        REQUIRE(client->post("http://127.0.0.1:1/echo", "text/plain", bigBody));
+        ioc.run();
+        REQUIRE(handler.error_ == "Request body exceeds maximum size");
+    }
 }

--- a/test/http_client_test.cpp
+++ b/test/http_client_test.cpp
@@ -1,0 +1,200 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "beauty/http_client.hpp"
+#include "beauty/i_http_client_handler.hpp"
+#include "beauty/reply.hpp"
+#include "beauty/request.hpp"
+#include "beauty/response.hpp"
+#include "beauty/server.hpp"
+
+using namespace std::literals::chrono_literals;
+using namespace beauty;
+
+namespace {
+
+// Records the outcome of an HTTP request and stops the io_context so the test
+// body can inspect the result. A per-response callback allows a test to issue a
+// follow-up request (e.g. to exercise keep-alive reuse).
+class TestHttpHandler : public IHttpClientHandler {
+   public:
+    explicit TestHttpHandler(asio::io_context &ioc) : ioc_(ioc) {}
+
+    void onResponse(const Response &response) override {
+        ++responseCount_;
+        lastStatus_ = response.statusCode_;
+        lastBody_.assign(response.body_.begin(), response.body_.end());
+        lastKeepAlive_ = response.keepAlive_;
+        if (onResponseCb_) {
+            onResponseCb_(response);
+        } else {
+            ioc_.stop();
+        }
+    }
+
+    void onError(const std::string &error) override {
+        error_ = error;
+        ioc_.stop();
+    }
+
+    int responseCount_ = 0;
+    int lastStatus_ = 0;
+    std::string lastBody_;
+    bool lastKeepAlive_ = false;
+    std::string error_;
+    std::function<void(const Response &)> onResponseCb_;
+
+   private:
+    asio::io_context &ioc_;
+};
+
+// Registers a request handler that serves a few fixed routes for the tests.
+void installRoutes(Server &server) {
+    server.addRequestHandler([](const Request &req, Reply &rep) {
+        if (req.requestPath_ == "/hello") {
+            std::string body = "hello world";
+            rep.content_.assign(body.begin(), body.end());
+            rep.send(Reply::ok, "text/plain");
+        } else if (req.requestPath_ == "/echo" && req.method_ == "POST") {
+            rep.content_.assign(req.body_.begin(), req.body_.end());
+            rep.send(Reply::ok, "application/octet-stream");
+        } else {
+            rep.send(Reply::not_found);
+        }
+    });
+}
+
+}  // namespace
+
+TEST_CASE("http client request/response", "[http_client]") {
+    asio::io_context ioc;
+    Settings settings(0s, 0, 0);  // keep-alive disabled: server closes after each response
+    Server server(ioc, "127.0.0.1", "0", settings);
+    uint16_t port = server.getBindedPort();
+    REQUIRE(port != 0);
+    installRoutes(server);
+
+    const std::string base = "http://127.0.0.1:" + std::to_string(port);
+
+    asio::steady_timer watchdog(ioc);
+    watchdog.expires_after(3s);
+    watchdog.async_wait([&ioc](const std::error_code &ec) {
+        if (!ec) {
+            ioc.stop();
+        }
+    });
+
+    SECTION("should GET a body with status 200") {
+        TestHttpHandler handler(ioc);
+        auto client = HttpClient::create(ioc, handler);
+        REQUIRE(client->get(base + "/hello"));
+        ioc.run();
+
+        REQUIRE(handler.error_.empty());
+        REQUIRE(handler.responseCount_ == 1);
+        REQUIRE(handler.lastStatus_ == 200);
+        REQUIRE(handler.lastBody_ == "hello world");
+    }
+
+    SECTION("should GET a URL without http:// scheme") {
+        TestHttpHandler handler(ioc);
+        auto client = HttpClient::create(ioc, handler);
+        std::string noScheme = "127.0.0.1:" + std::to_string(port) + "/hello";
+        REQUIRE(client->get(noScheme));
+        ioc.run();
+
+        REQUIRE(handler.error_.empty());
+        REQUIRE(handler.responseCount_ == 1);
+        REQUIRE(handler.lastStatus_ == 200);
+        REQUIRE(handler.lastBody_ == "hello world");
+    }
+
+    SECTION("should report 404 for an unknown path") {
+        TestHttpHandler handler(ioc);
+        auto client = HttpClient::create(ioc, handler);
+        REQUIRE(client->get(base + "/nope"));
+        ioc.run();
+
+        REQUIRE(handler.error_.empty());
+        REQUIRE(handler.lastStatus_ == 404);
+    }
+
+    SECTION("should POST a body and receive it echoed back") {
+        TestHttpHandler handler(ioc);
+        auto client = HttpClient::create(ioc, handler);
+        REQUIRE(client->post(base + "/echo", "text/plain", "payload-123"));
+        ioc.run();
+
+        REQUIRE(handler.error_.empty());
+        REQUIRE(handler.lastStatus_ == 200);
+        REQUIRE(handler.lastBody_ == "payload-123");
+    }
+}
+
+TEST_CASE("http client keep-alive reuse", "[http_client]") {
+    asio::io_context ioc;
+    Settings settings(5s, 100, 0);  // keep-alive enabled
+    Server server(ioc, "127.0.0.1", "0", settings);
+    uint16_t port = server.getBindedPort();
+    REQUIRE(port != 0);
+    installRoutes(server);
+
+    const std::string base = "http://127.0.0.1:" + std::to_string(port);
+
+    asio::steady_timer watchdog(ioc);
+    watchdog.expires_after(3s);
+    watchdog.async_wait([&ioc](const std::error_code &ec) {
+        if (!ec) {
+            ioc.stop();
+        }
+    });
+
+    SECTION("should perform two sequential requests on one client") {
+        TestHttpHandler handler(ioc);
+        auto client = HttpClient::create(ioc, handler);
+
+        handler.onResponseCb_ = [&](const Response &) {
+            if (handler.responseCount_ == 1) {
+                // Issue the second request from within the first response.
+                client->get(base + "/hello");
+            } else {
+                ioc.stop();
+            }
+        };
+
+        REQUIRE(client->get(base + "/hello"));
+        ioc.run();
+
+        REQUIRE(handler.error_.empty());
+        REQUIRE(handler.responseCount_ == 2);
+        REQUIRE(handler.lastStatus_ == 200);
+        REQUIRE(handler.lastBody_ == "hello world");
+    }
+}
+
+TEST_CASE("http client error handling", "[http_client]") {
+    asio::io_context ioc;
+
+    SECTION("should report an error for an invalid URL") {
+        TestHttpHandler handler(ioc);
+        auto client = HttpClient::create(ioc, handler);
+        REQUIRE(client->get("http://"));  // no hostname
+        ioc.run();
+        REQUIRE_FALSE(handler.error_.empty());
+    }
+
+    SECTION("should report an error when the connection is refused") {
+        // Port 1 is almost never listening; connect should fail quickly.
+        TestHttpHandler handler(ioc);
+        HttpClient::Config config;
+        config.requestTimeout = 2s;
+        auto client = HttpClient::create(ioc, handler, config);
+        REQUIRE(client->get("http://127.0.0.1:1/"));
+        ioc.run();
+        REQUIRE_FALSE(handler.error_.empty());
+    }
+}

--- a/test/response_parser_test.cpp
+++ b/test/response_parser_test.cpp
@@ -179,3 +179,145 @@ TEST_CASE("parse websocket upgrade", "[response_parser]") {
         REQUIRE(std::string(fixture.recvBuffer_.begin(), fixture.recvBuffer_.end()) == "FRAMEDATA");
     }
 }
+
+TEST_CASE("parse 1xx interim responses", "[response_parser]") {
+    ResponseFixture fixture(1024);
+
+    SECTION("should skip a 100 Continue and parse the final response") {
+        auto result = fixture.parse_complete(
+            "HTTP/1.1 100 Continue\r\n"
+            "\r\n"
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 5\r\n"
+            "\r\n"
+            "hello");
+        REQUIRE(result == ResponseParser::good_complete);
+        REQUIRE(fixture.response.statusCode_ == 200);
+        REQUIRE(bodyAsString(fixture.response) == "hello");
+    }
+
+    SECTION("should skip an interim response that arrives before the final one") {
+        auto result = fixture.parse_chunk("HTTP/1.1 100 Continue\r\n\r\n");
+        REQUIRE(result == ResponseParser::good_part);
+        result = fixture.parse_chunk(
+            "HTTP/1.1 201 Created\r\n"
+            "Content-Length: 2\r\n"
+            "\r\n"
+            "ok");
+        REQUIRE(result == ResponseParser::good_complete);
+        REQUIRE(fixture.response.statusCode_ == 201);
+        REQUIRE(bodyAsString(fixture.response) == "ok");
+    }
+}
+
+TEST_CASE("parse chunked transfer encoding", "[response_parser]") {
+    ResponseFixture fixture(1024);
+
+    SECTION("should decode a simple chunked body") {
+        auto result = fixture.parse_complete(
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "\r\n"
+            "5\r\nhello\r\n"
+            "6\r\n world\r\n"
+            "0\r\n"
+            "\r\n");
+        REQUIRE(result == ResponseParser::good_complete);
+        REQUIRE(bodyAsString(fixture.response) == "hello world");
+    }
+
+    SECTION("should ignore chunk extensions") {
+        auto result = fixture.parse_complete(
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "\r\n"
+            "5;foo=bar\r\nhello\r\n"
+            "0\r\n"
+            "\r\n");
+        REQUIRE(result == ResponseParser::good_complete);
+        REQUIRE(bodyAsString(fixture.response) == "hello");
+    }
+
+    SECTION("should skip trailers after the last chunk") {
+        auto result = fixture.parse_complete(
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "\r\n"
+            "3\r\nabc\r\n"
+            "0\r\n"
+            "X-Trailer: value\r\n"
+            "\r\n");
+        REQUIRE(result == ResponseParser::good_complete);
+        REQUIRE(bodyAsString(fixture.response) == "abc");
+    }
+
+    SECTION("should decode chunked body fed incrementally") {
+        auto result = fixture.parse_chunk(
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "\r\n"
+            "5\r\nhel");
+        REQUIRE(result == ResponseParser::good_part);
+        result = fixture.parse_chunk("lo\r\n0\r\n\r\n");
+        REQUIRE(result == ResponseParser::good_complete);
+        REQUIRE(bodyAsString(fixture.response) == "hello");
+    }
+
+    SECTION("should decode hex chunk sizes larger than 9") {
+        auto result = fixture.parse_complete(
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "\r\n"
+            "a\r\n0123456789\r\n"
+            "0\r\n\r\n");
+        REQUIRE(result == ResponseParser::good_complete);
+        REQUIRE(bodyAsString(fixture.response) == "0123456789");
+    }
+}
+
+TEST_CASE("parse body delimited by connection close", "[response_parser]") {
+    ResponseFixture fixture(1024);
+
+    SECTION("finish() completes a body with no Content-Length") {
+        auto result = fixture.parse_complete(
+            "HTTP/1.0 200 OK\r\n"
+            "\r\n"
+            "some body bytes");
+        REQUIRE(result == ResponseParser::good_part);
+        result = fixture.parser.finish(fixture.response);
+        REQUIRE(result == ResponseParser::good_complete);
+        REQUIRE(bodyAsString(fixture.response) == "some body bytes");
+    }
+
+    SECTION("finish() reports bad when closed mid-headers") {
+        auto result = fixture.parse_complete("HTTP/1.1 200 OK\r\nContent-Len");
+        REQUIRE(result == ResponseParser::good_part);
+        result = fixture.parser.finish(fixture.response);
+        REQUIRE(result == ResponseParser::bad);
+    }
+}
+
+TEST_CASE("parse enforces max body size", "[response_parser]") {
+    ResponseFixture fixture(1024);
+
+    SECTION("should reject a Content-Length body that exceeds the limit") {
+        fixture.parser.setMaxBodySize(4);
+        auto result = fixture.parse_complete(
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 10\r\n"
+            "\r\n"
+            "0123456789");
+        REQUIRE(result == ResponseParser::too_large);
+    }
+
+    SECTION("should reject a chunked body that exceeds the limit") {
+        fixture.parser.setMaxBodySize(4);
+        auto result = fixture.parse_complete(
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "\r\n"
+            "a\r\n0123456789\r\n"
+            "0\r\n\r\n");
+        REQUIRE(result == ResponseParser::too_large);
+    }
+}

--- a/test/url_parser_test.cpp
+++ b/test/url_parser_test.cpp
@@ -28,6 +28,18 @@ TEST_CASE("http", "[url_parser]") {
         REQUIRE(parser.path() == "/");
     }
 
+    SECTION("it should parse hostname with port but no path") {
+        const char *text = "http://127.0.0.1:8080";
+        UrlParser parser(text);
+
+        REQUIRE(parser.isValid() == true);
+        REQUIRE(parser.scheme() == "http");
+        REQUIRE(parser.hostname() == "127.0.0.1");
+        REQUIRE(parser.port() == "8080");
+        REQUIRE(parser.httpPort() == 8080);
+        REQUIRE(parser.path() == "/");
+    }
+
     SECTION("it should parse url with username") {
         const char *text =
             "http://username@www.example.com/dir/subdir?param=1&param=2;param%20=%20#fragment";


### PR DESCRIPTION
This PR extends the Beauty client to perform regular HTTP requests, following the same ESP32-friendly, fixed-buffer, single-io_context design principles used by the existing WsClient.

The PR includes:
ResponseParser — added chunked transfer-decoding, 1xx interim-response skipping (a 100 Continue was previously mis-reported as complete), EOF-delimited body support via finish(), and a too_large guard driven by setMaxBodySize().

HttpClient — a new shared-pointer async client with get/head/del/post/put/request, a request-timeout timer, a response-size guard, and optional keep-alive connection reuse. Errors are delivered asynchronously via the handler interface.

IHttpClientHandler — onResponse / onError callback interface.

Tests — 3 cases covering request/response, keep-alive reuse, and error handling (invalid URL, connection refused).

Example — a CLI beauty_http_client_example target

Verification: Full build clean; entire suite green — 77 test cases, 21892 assertions

Decisions made autonomously: Chunked decoding and 1xx skipping enabled; HttpClient kept as a separate class; no auto-reconnect or send-side Expect-100. 