### PR TITLE
PWS-842 Add ssl support to Beauty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ if(NOT IDF_PATH)
 	endif()
 
 	include(CTest)
+
 	if(BUILD_TESTING)
 		add_subdirectory(test)
 	endif()
@@ -23,9 +24,20 @@ if(NOT IDF_PATH)
 
 	target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE asio::asio cjson)
 
-	target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC 
-	    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-	    $<INSTALL_INTERFACE:include>
+	# Optional SSL/TLS support via OpenSSL
+	find_package(OpenSSL QUIET)
+
+	if(OpenSSL_FOUND)
+		target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+		target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC BEAUTY_ENABLE_SSL)
+		message(STATUS "Beauty: SSL/TLS support enabled (OpenSSL ${OPENSSL_VERSION})")
+	else()
+		message(STATUS "Beauty: SSL/TLS support disabled (OpenSSL not found)")
+	endif()
+
+	target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+		$<INSTALL_INTERFACE:include>
 	)
 
 	target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)
@@ -54,7 +66,8 @@ endif()
 
 # --- ESP-IDF component support: only active when included as a component ---
 if(IDF_PATH)
-	file (GLOB beauty_sources "src/*.cpp")
+	file(GLOB beauty_sources "src/*.cpp")
+
 	# Register as ESP-IDF component
 	idf_component_register(
 		SRCS ${beauty_sources}

--- a/README.md
+++ b/README.md
@@ -1209,8 +1209,8 @@ beauty::HttpClient::Config config;
 config.maxResponseSize = 4096;
 config.requestTimeout  = std::chrono::seconds(10);
 
-auto socket = std::make_unique<beauty::SslSocket>(ioc, sslCtx);
-auto client = beauty::HttpClient::create(ioc, handler, config, std::move(socket));
+auto socket = std::shared_ptr<beauty::ISocket>(new beauty::SslSocket(ioc, sslCtx));
+auto client = beauty::HttpClient::create(ioc, handler, config, socket);
 
 client->get("https://www.example.com/");
 ioc.run();

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Beauty was born with the realization that Asio is supported on ESP32 microcontro
   - [🔌 WebSocket Support](#-websocket-support)
   - [📡 WebSocket Client](#-websocket-client)
   - [🌐 HTTP Client](#-http-client)
+  - [🔒 SSL/TLS Support](#-ssltls-support)
 
 ## 📦 Dependencies
 - **Asio (non-boost)** - Async I/O operations
@@ -1130,5 +1131,121 @@ A ready-to-run example is provided under `examples/pc`:
 # POST request with body
 ./build/examples/beauty_http_client_example http://127.0.0.1:8080/api POST '{"key":"value"}'
 ```
+
+## 🔒 SSL/TLS Support
+
+Beauty supports SSL/TLS for the server, HTTP client, and WebSocket client
+through ASIO's SSL layer. On ESP-IDF the underlying crypto is provided by
+mbedTLS (hardware-accelerated on most ESP32 variants); on PC/Linux it uses
+OpenSSL.
+
+### Prerequisites
+
+| Platform | Requirement |
+|----------|------------|
+| **ESP-IDF** | Enable `CONFIG_ASIO_SSL_SUPPORT=y` in menuconfig (`Component config → ESP-ASIO → Enable SSL/TLS support for ASIO`) |
+| **PC/Linux** | Install OpenSSL development headers (`libssl-dev` / `openssl-devel`) |
+
+### HTTPS Server
+
+Create an `asio::ssl::context`, load your certificate and private key, and
+pass it to the `Server` constructor. Beauty will accept TLS connections and
+perform the handshake automatically before reading HTTP requests.
+
+```cpp
+#include <asio/ssl.hpp>
+#include "beauty/server.hpp"
+#include "beauty/ssl_socket.hpp"
+
+asio::io_context ioc;
+
+// Set up SSL context
+asio::ssl::context sslCtx(asio::ssl::context::tlsv12);
+sslCtx.set_options(asio::ssl::context::default_workarounds |
+                   asio::ssl::context::no_sslv2);
+
+// Load cert chain and private key (must be null-terminated for mbedTLS)
+std::string certPem = /* read from file */;
+std::string keyPem  = /* read from file */;
+sslCtx.use_certificate_chain(asio::buffer(certPem.c_str(), certPem.size() + 1));
+sslCtx.use_private_key(asio::buffer(keyPem.c_str(), keyPem.size() + 1),
+                       asio::ssl::context::pem);
+
+beauty::Settings settings(std::chrono::seconds(5), 1000, 20);
+
+// HTTPS on port 443
+beauty::Server httpsServer(ioc, 443, sslCtx, settings, 4096);
+httpsServer.setFileIO(&fileIO);
+httpsServer.addRequestHandler(myHandler);
+
+// Optional: plain HTTP fallback on port 80 (dual-port)
+beauty::Server httpServer(ioc, 80, settings, 4096);
+httpServer.setFileIO(&fileIO);
+httpServer.addRequestHandler(myHandler);
+
+ioc.run();
+```
+
+> **Note (mbedTLS):** PEM buffers passed to `use_certificate_chain()` and
+> `use_private_key()` must be **null-terminated**. Use
+> `asio::buffer(pem.c_str(), pem.size() + 1)` to include the terminator.
+
+### HTTPS Client
+
+Pass a pre-configured `SslSocket` to `HttpClient::create()`:
+
+```cpp
+#include <asio/ssl.hpp>
+#include "beauty/http_client.hpp"
+#include "beauty/ssl_socket.hpp"
+
+asio::io_context ioc;
+MyHandler handler;
+
+asio::ssl::context sslCtx(asio::ssl::context::tlsv12_client);
+sslCtx.set_default_verify_paths();  // Use system CA bundle
+
+beauty::HttpClient::Config config;
+config.maxResponseSize = 4096;
+config.requestTimeout  = std::chrono::seconds(10);
+
+auto socket = std::make_unique<beauty::SslSocket>(ioc, sslCtx);
+auto client = beauty::HttpClient::create(ioc, handler, config, std::move(socket));
+
+client->get("https://www.example.com/");
+ioc.run();
+```
+
+### Memory Considerations (ESP32)
+
+Each TLS connection uses approximately 40–60 KB of heap for mbedTLS session
+state and crypto buffers. Plan for 2–4 concurrent HTTPS connections on
+typical ESP32 devices. The `CONFIG_ASIO_SSL_BIO_SIZE` setting (default 1024)
+controls the per-connection BIO buffer — increase it if TLS throughput is
+insufficient.
+
+### Known Limitations (ESP-IDF)
+
+- **HTTPS server** works fully — certificate loading, TLS handshake, and
+  encrypted HTTP serving are all functional.
+- **HTTPS client** is architecturally supported (the `ISocket`/`SslSocket`
+  plumbing is in place), but ESP-IDF's ASIO SSL port (mbedTLS-backed) does
+  not implement client-side context APIs such as `set_verify_mode()`,
+  `set_default_verify_paths()`, or SNI configuration. HTTPS client
+  connections require ESP-IDF ASIO port enhancements. On PC builds with
+  OpenSSL, the HTTPS client works without restrictions.
+
+### Architecture
+
+SSL/TLS is implemented through a type-erased socket interface (`ISocket`)
+with two implementations:
+
+- `PlainSocket` — wraps `asio::ip::tcp::socket` (no encryption)
+- `SslSocket` — wraps `asio::ssl::stream<tcp::socket>` (TLS encryption)
+
+This design keeps `Connection`, `HttpClient`, and `WsClient` as non-template
+classes with zero overhead for plain HTTP builds. The virtual dispatch cost
+per I/O operation is negligible compared to actual network and crypto
+processing.
 
 

--- a/src/asio_ssl_impl.cpp
+++ b/src/asio_ssl_impl.cpp
@@ -1,0 +1,8 @@
+// ASIO SSL separate compilation unit.
+// When ASIO is built with ASIO_SEPARATE_COMPILATION (as the asio.cmake
+// wrapper does), the SSL implementation must be compiled in exactly one
+// translation unit.  This file is only compiled when BEAUTY_ENABLE_SSL
+// is defined.
+#ifdef BEAUTY_ENABLE_SSL
+#include <asio/ssl/impl/src.hpp>
+#endif

--- a/src/beauty/connection.hpp
+++ b/src/beauty/connection.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <memory>
 
+#include "beauty/i_socket.hpp"
 #include "beauty/reply.hpp"
 #include "beauty/request.hpp"
 #include "beauty/request_decoder.hpp"
@@ -29,7 +30,7 @@ class Connection : public std::enable_shared_from_this<Connection> {
     Connection &operator=(const Connection &) = delete;
 
     // Construct a connection with the given socket.
-    explicit Connection(asio::ip::tcp::socket socket,
+    explicit Connection(std::unique_ptr<ISocket> socket,
                         ConnectionManager &manager,
                         RequestHandler &handler,
                         unsigned connectionId,
@@ -84,7 +85,7 @@ class Connection : public std::enable_shared_from_this<Connection> {
     void shutdown();
 
     // Socket for the connection.
-    asio::ip::tcp::socket socket_;
+    std::unique_ptr<ISocket> socket_;
 
     // The manager for this connection.
     ConnectionManager &connectionManager_;

--- a/src/beauty/connection.hpp
+++ b/src/beauty/connection.hpp
@@ -26,13 +26,13 @@ class WsEndpoint;
 // Represents a single connection from a client.
 class Connection : public std::enable_shared_from_this<Connection> {
    public:
-    Connection(const Connection &) = delete;
-    Connection &operator=(const Connection &) = delete;
+    Connection(const Connection&) = delete;
+    Connection& operator=(const Connection&) = delete;
 
     // Construct a connection with the given socket.
-    explicit Connection(std::unique_ptr<ISocket> socket,
-                        ConnectionManager &manager,
-                        RequestHandler &handler,
+    explicit Connection(std::shared_ptr<ISocket> socket,
+                        ConnectionManager& manager,
+                        RequestHandler& handler,
                         unsigned connectionId,
                         size_t maxContentSize);
     ~Connection() = default;
@@ -52,16 +52,16 @@ class Connection : public std::enable_shared_from_this<Connection> {
     bool useKeepAlive() const;
     bool isWebSocket() const;
     unsigned getConnectionId() const;
-    WsEndpoint *getWsEndpoint() const;
+    WsEndpoint* getWsEndpoint() const;
     void sendWsPing();
 
     // WebSocket write state query
     bool isWriteInProgress() const;
 
-    WriteResult sendWsText(const std::string &message, WriteCompleteCallback callback);
-    WriteResult sendWsBinary(const std::vector<char> &data, WriteCompleteCallback callback);
+    WriteResult sendWsText(const std::string& message, WriteCompleteCallback callback);
+    WriteResult sendWsBinary(const std::vector<char>& data, WriteCompleteCallback callback);
     WriteResult sendWsClose(uint16_t statusCode = 1000,
-                            const std::string &reason = "",
+                            const std::string& reason = "",
                             WriteCompleteCallback callback = nullptr);
 
    private:
@@ -85,13 +85,13 @@ class Connection : public std::enable_shared_from_this<Connection> {
     void shutdown();
 
     // Socket for the connection.
-    std::unique_ptr<ISocket> socket_;
+    std::shared_ptr<ISocket> socket_;
 
     // The manager for this connection.
-    ConnectionManager &connectionManager_;
+    ConnectionManager& connectionManager_;
 
     // The handler used to process the incoming request.
-    RequestHandler &requestHandler_;
+    RequestHandler& requestHandler_;
 
     // The unique id for the connection.
     unsigned connectionId_;
@@ -133,7 +133,7 @@ class Connection : public std::enable_shared_from_this<Connection> {
     std::chrono::steady_clock::time_point lastPongTime_;
 
     // The WebSocket endpoint for this connection (set during upgrade).
-    WsEndpoint *wsEndpoint_ = nullptr;
+    WsEndpoint* wsEndpoint_ = nullptr;
 
     // The received message over WebSocket.
     WsMessage wsMessage_;

--- a/src/beauty/http_client.hpp
+++ b/src/beauty/http_client.hpp
@@ -50,45 +50,45 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
         bool keepAlive = true;
     };
 
-    HttpClient(const HttpClient &) = delete;
-    HttpClient &operator=(const HttpClient &) = delete;
+    HttpClient(const HttpClient&) = delete;
+    HttpClient& operator=(const HttpClient&) = delete;
 
-    static std::shared_ptr<HttpClient> create(asio::io_context &ioContext,
-                                              IHttpClientHandler &handler,
-                                              const Config &config);
+    static std::shared_ptr<HttpClient> create(asio::io_context& ioContext,
+                                              IHttpClientHandler& handler,
+                                              const Config& config);
 
-    static std::shared_ptr<HttpClient> create(asio::io_context &ioContext,
-                                              IHttpClientHandler &handler);
+    static std::shared_ptr<HttpClient> create(asio::io_context& ioContext,
+                                              IHttpClientHandler& handler);
 
     // Create an HTTPS client. The caller must keep sslCtx alive for the
     // lifetime of the client.
-    static std::shared_ptr<HttpClient> create(asio::io_context &ioContext,
-                                              IHttpClientHandler &handler,
-                                              const Config &config,
-                                              std::unique_ptr<ISocket> socket);
+    static std::shared_ptr<HttpClient> create(asio::io_context& ioContext,
+                                              IHttpClientHandler& handler,
+                                              const Config& config,
+                                              std::shared_ptr<ISocket> socket);
 
     ~HttpClient() = default;
 
     // Perform an HTTP request against the given http:// URL. Returns false (and
     // does nothing) if a request is already in progress. On completion either
     // onResponse or onError is invoked exactly once.
-    bool request(const std::string &method,
-                 const std::string &url,
-                 const std::vector<Header> &headers = std::vector<Header>(),
-                 const std::string &body = std::string());
+    bool request(const std::string& method,
+                 const std::string& url,
+                 const std::vector<Header>& headers = std::vector<Header>(),
+                 const std::string& body = std::string());
 
     // Convenience wrappers around request().
-    bool get(const std::string &url, const std::vector<Header> &headers = std::vector<Header>());
-    bool head(const std::string &url, const std::vector<Header> &headers = std::vector<Header>());
-    bool del(const std::string &url, const std::vector<Header> &headers = std::vector<Header>());
-    bool post(const std::string &url,
-              const std::string &contentType,
-              const std::string &body,
-              const std::vector<Header> &headers = std::vector<Header>());
-    bool put(const std::string &url,
-             const std::string &contentType,
-             const std::string &body,
-             const std::vector<Header> &headers = std::vector<Header>());
+    bool get(const std::string& url, const std::vector<Header>& headers = std::vector<Header>());
+    bool head(const std::string& url, const std::vector<Header>& headers = std::vector<Header>());
+    bool del(const std::string& url, const std::vector<Header>& headers = std::vector<Header>());
+    bool post(const std::string& url,
+              const std::string& contentType,
+              const std::string& body,
+              const std::vector<Header>& headers = std::vector<Header>());
+    bool put(const std::string& url,
+             const std::string& contentType,
+             const std::string& body,
+             const std::vector<Header>& headers = std::vector<Header>());
 
     // Close the underlying connection (if any). Does not fire any callback.
     void close();
@@ -99,28 +99,30 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
     }
 
    private:
-    HttpClient(asio::io_context &ioContext, IHttpClientHandler &handler, const Config &config,
-               std::unique_ptr<ISocket> socket);
+    HttpClient(asio::io_context& ioContext,
+               IHttpClientHandler& handler,
+               const Config& config,
+               std::shared_ptr<ISocket> socket);
 
     void startRequest();
     void doResolve();
-    void doConnect(const asio::ip::tcp::resolver::results_type &endpoints);
+    void doConnect(const asio::ip::tcp::resolver::results_type& endpoints);
     void doHandshake();
     void doWriteRequest();
     void doReadResponse();
     void startTimeoutTimer();
 
     void deliverResponse();
-    void reportError(const std::string &error);
+    void reportError(const std::string& error);
     void closeSocket();
-    bool sameTarget(const std::string &host, const std::string &port) const;
+    bool sameTarget(const std::string& host, const std::string& port) const;
 
-    asio::io_context &ioContext_;
+    asio::io_context& ioContext_;
     asio::ip::tcp::resolver resolver_;
-    std::unique_ptr<ISocket> socket_;
+    std::shared_ptr<ISocket> socket_;
     asio::steady_timer timeoutTimer_;
 
-    IHttpClientHandler &handler_;
+    IHttpClientHandler& handler_;
     Config config_;
 
     // Fixed maximum size buffers.
@@ -144,27 +146,27 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
     std::string connectedPort_;
 };
 
-inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
-                                                      IHttpClientHandler &handler,
-                                                      const Config &config) {
-    return std::shared_ptr<HttpClient>(
-        new HttpClient(ioContext, handler, config,
-                       std::unique_ptr<PlainSocket>(new PlainSocket(ioContext))));
+inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context& ioContext,
+                                                      IHttpClientHandler& handler,
+                                                      const Config& config) {
+    return std::shared_ptr<HttpClient>(new HttpClient(
+        ioContext, handler, config,
+        std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
 }
 
-inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
-                                                      IHttpClientHandler &handler) {
-    return std::shared_ptr<HttpClient>(
-        new HttpClient(ioContext, handler, Config(),
-                       std::unique_ptr<PlainSocket>(new PlainSocket(ioContext))));
+inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context& ioContext,
+                                                      IHttpClientHandler& handler) {
+    return std::shared_ptr<HttpClient>(new HttpClient(
+        ioContext, handler, Config(),
+        std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
 }
 
-inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
-                                                      IHttpClientHandler &handler,
-                                                      const Config &config,
-                                                      std::unique_ptr<ISocket> socket) {
+inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context& ioContext,
+                                                      IHttpClientHandler& handler,
+                                                      const Config& config,
+                                                      std::shared_ptr<ISocket> socket) {
     return std::shared_ptr<HttpClient>(
-        new HttpClient(ioContext, handler, config, std::move(socket)));
+        new HttpClient(ioContext, handler, config, socket));
 }
 
 }  // namespace beauty

--- a/src/beauty/http_client.hpp
+++ b/src/beauty/http_client.hpp
@@ -150,23 +150,20 @@ inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context& ioContex
                                                       IHttpClientHandler& handler,
                                                       const Config& config) {
     return std::shared_ptr<HttpClient>(new HttpClient(
-        ioContext, handler, config,
-        std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
+        ioContext, handler, config, std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
 }
 
 inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context& ioContext,
                                                       IHttpClientHandler& handler) {
     return std::shared_ptr<HttpClient>(new HttpClient(
-        ioContext, handler, Config(),
-        std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
+        ioContext, handler, Config(), std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
 }
 
 inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context& ioContext,
                                                       IHttpClientHandler& handler,
                                                       const Config& config,
                                                       std::shared_ptr<ISocket> socket) {
-    return std::shared_ptr<HttpClient>(
-        new HttpClient(ioContext, handler, config, socket));
+    return std::shared_ptr<HttpClient>(new HttpClient(ioContext, handler, config, socket));
 }
 
 }  // namespace beauty

--- a/src/beauty/http_client.hpp
+++ b/src/beauty/http_client.hpp
@@ -11,6 +11,7 @@
 
 #include "beauty/header.hpp"
 #include "beauty/i_http_client_handler.hpp"
+#include "beauty/i_socket.hpp"
 #include "beauty/response.hpp"
 #include "beauty/response_parser.hpp"
 #include "beauty/url_parser.hpp"
@@ -59,6 +60,13 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
     static std::shared_ptr<HttpClient> create(asio::io_context &ioContext,
                                               IHttpClientHandler &handler);
 
+    // Create an HTTPS client. The caller must keep sslCtx alive for the
+    // lifetime of the client.
+    static std::shared_ptr<HttpClient> create(asio::io_context &ioContext,
+                                              IHttpClientHandler &handler,
+                                              const Config &config,
+                                              std::unique_ptr<ISocket> socket);
+
     ~HttpClient() = default;
 
     // Perform an HTTP request against the given http:// URL. Returns false (and
@@ -91,11 +99,13 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
     }
 
    private:
-    HttpClient(asio::io_context &ioContext, IHttpClientHandler &handler, const Config &config);
+    HttpClient(asio::io_context &ioContext, IHttpClientHandler &handler, const Config &config,
+               std::unique_ptr<ISocket> socket);
 
     void startRequest();
     void doResolve();
     void doConnect(const asio::ip::tcp::resolver::results_type &endpoints);
+    void doHandshake();
     void doWriteRequest();
     void doReadResponse();
     void startTimeoutTimer();
@@ -107,7 +117,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
 
     asio::io_context &ioContext_;
     asio::ip::tcp::resolver resolver_;
-    asio::ip::tcp::socket socket_;
+    std::unique_ptr<ISocket> socket_;
     asio::steady_timer timeoutTimer_;
 
     IHttpClientHandler &handler_;
@@ -137,12 +147,24 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
 inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
                                                       IHttpClientHandler &handler,
                                                       const Config &config) {
-    return std::shared_ptr<HttpClient>(new HttpClient(ioContext, handler, config));
+    return std::shared_ptr<HttpClient>(
+        new HttpClient(ioContext, handler, config,
+                       std::unique_ptr<PlainSocket>(new PlainSocket(ioContext))));
 }
 
 inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
                                                       IHttpClientHandler &handler) {
-    return std::shared_ptr<HttpClient>(new HttpClient(ioContext, handler, Config()));
+    return std::shared_ptr<HttpClient>(
+        new HttpClient(ioContext, handler, Config(),
+                       std::unique_ptr<PlainSocket>(new PlainSocket(ioContext))));
+}
+
+inline std::shared_ptr<HttpClient> HttpClient::create(asio::io_context &ioContext,
+                                                      IHttpClientHandler &handler,
+                                                      const Config &config,
+                                                      std::unique_ptr<ISocket> socket) {
+    return std::shared_ptr<HttpClient>(
+        new HttpClient(ioContext, handler, config, std::move(socket)));
 }
 
 }  // namespace beauty

--- a/src/beauty/i_socket.hpp
+++ b/src/beauty/i_socket.hpp
@@ -24,8 +24,7 @@ class ISocket {
     virtual void asyncReadSome(const asio::mutable_buffer& buffer, IoHandler handler) = 0;
 
     // Asynchronous write of a buffer sequence.
-    virtual void asyncWrite(const std::vector<asio::const_buffer>& buffers,
-                            IoHandler handler) = 0;
+    virtual void asyncWrite(const std::vector<asio::const_buffer>& buffers, IoHandler handler) = 0;
 
     // Close the underlying socket.
     virtual void close() = 0;
@@ -75,9 +74,13 @@ class PlainSocket : public ISocket {
         socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
     }
 
-    bool isOpen() const override { return socket_.is_open(); }
+    bool isOpen() const override {
+        return socket_.is_open();
+    }
 
-    bool needsHandshake() const override { return false; }
+    bool needsHandshake() const override {
+        return false;
+    }
 
     void asyncConnect(const asio::ip::tcp::resolver::results_type& endpoints,
                       ConnectHandler handler) override {
@@ -89,7 +92,9 @@ class PlainSocket : public ISocket {
         handler(std::error_code());
     }
 
-    asio::ip::tcp::socket& tcpSocket() override { return socket_; }
+    asio::ip::tcp::socket& tcpSocket() override {
+        return socket_;
+    }
 
    private:
     asio::ip::tcp::socket socket_;

--- a/src/beauty/i_socket.hpp
+++ b/src/beauty/i_socket.hpp
@@ -1,0 +1,98 @@
+#pragma once
+#include "beauty/environment.hpp"
+
+#include <asio.hpp>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace beauty {
+
+// Type-erased socket interface. Wraps either a plain TCP socket or an SSL
+// stream so that Connection, HttpClient, and WsClient can operate on both
+// without being templates.
+class ISocket {
+   public:
+    using IoHandler = std::function<void(const std::error_code&, std::size_t)>;
+    using ErrorHandler = std::function<void(const std::error_code&)>;
+    using ConnectHandler =
+        std::function<void(const std::error_code&, const asio::ip::tcp::endpoint&)>;
+
+    virtual ~ISocket() = default;
+
+    // Asynchronous read into a contiguous mutable buffer.
+    virtual void asyncReadSome(const asio::mutable_buffer& buffer, IoHandler handler) = 0;
+
+    // Asynchronous write of a buffer sequence.
+    virtual void asyncWrite(const std::vector<asio::const_buffer>& buffers,
+                            IoHandler handler) = 0;
+
+    // Close the underlying socket.
+    virtual void close() = 0;
+
+    // Graceful TCP shutdown.
+    virtual void shutdown(std::error_code& ec) = 0;
+
+    // Whether the underlying socket is open.
+    virtual bool isOpen() const = 0;
+
+    // Whether a TLS handshake is required before I/O. PlainSocket returns
+    // false; SslSocket returns true.
+    virtual bool needsHandshake() const = 0;
+
+    // Asynchronous connect (client-side).
+    virtual void asyncConnect(const asio::ip::tcp::resolver::results_type& endpoints,
+                              ConnectHandler handler) = 0;
+
+    // Perform an SSL/TLS handshake. For plain sockets this calls the handler
+    // synchronously with a success error_code (no-op).
+    virtual void asyncHandshake(bool isServer, ErrorHandler handler) = 0;
+
+    // Access the underlying TCP socket (for accept, socket options, etc.).
+    virtual asio::ip::tcp::socket& tcpSocket() = 0;
+};
+
+// Plain (unencrypted) TCP socket implementation of ISocket.
+class PlainSocket : public ISocket {
+   public:
+    explicit PlainSocket(asio::io_context& ioc) : socket_(ioc) {}
+    explicit PlainSocket(asio::ip::tcp::socket socket) : socket_(std::move(socket)) {}
+
+    void asyncReadSome(const asio::mutable_buffer& buffer, IoHandler handler) override {
+        socket_.async_read_some(buffer, std::move(handler));
+    }
+
+    void asyncWrite(const std::vector<asio::const_buffer>& buffers, IoHandler handler) override {
+        asio::async_write(socket_, buffers, std::move(handler));
+    }
+
+    void close() override {
+        std::error_code ec;
+        socket_.close(ec);
+    }
+
+    void shutdown(std::error_code& ec) override {
+        socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+    }
+
+    bool isOpen() const override { return socket_.is_open(); }
+
+    bool needsHandshake() const override { return false; }
+
+    void asyncConnect(const asio::ip::tcp::resolver::results_type& endpoints,
+                      ConnectHandler handler) override {
+        asio::async_connect(socket_, endpoints, std::move(handler));
+    }
+
+    void asyncHandshake(bool /*isServer*/, ErrorHandler handler) override {
+        // No TLS — call handler synchronously with success.
+        handler(std::error_code());
+    }
+
+    asio::ip::tcp::socket& tcpSocket() override { return socket_; }
+
+   private:
+    asio::ip::tcp::socket socket_;
+};
+
+}  // namespace beauty

--- a/src/beauty/i_socket.hpp
+++ b/src/beauty/i_socket.hpp
@@ -26,6 +26,10 @@ class ISocket {
     // Asynchronous write of a buffer sequence.
     virtual void asyncWrite(const std::vector<asio::const_buffer>& buffers, IoHandler handler) = 0;
 
+    // Asynchronous write of a single contiguous buffer (avoids vector
+    // allocation on the hot path).
+    virtual void asyncWrite(const asio::const_buffer& buffer, IoHandler handler) = 0;
+
     // Close the underlying socket.
     virtual void close() = 0;
 
@@ -63,6 +67,10 @@ class PlainSocket : public ISocket {
 
     void asyncWrite(const std::vector<asio::const_buffer>& buffers, IoHandler handler) override {
         asio::async_write(socket_, buffers, std::move(handler));
+    }
+
+    void asyncWrite(const asio::const_buffer& buffer, IoHandler handler) override {
+        asio::async_write(socket_, buffer, std::move(handler));
     }
 
     void close() override {

--- a/src/beauty/server.hpp
+++ b/src/beauty/server.hpp
@@ -11,9 +11,18 @@
 #include "beauty/connection.hpp"
 #include "beauty/connection_manager.hpp"
 #include "beauty/i_file_io.hpp"
+#include "beauty/i_socket.hpp"
 #include "beauty/i_ws_receiver.hpp"
 #include "beauty/request_handler.hpp"
 #include "beauty/ws_endpoint.hpp"
+
+// Forward-declare ssl::context to avoid pulling in <asio/ssl.hpp> when SSL is
+// not used.
+namespace asio {
+namespace ssl {
+class context;
+}
+}  // namespace asio
 
 namespace beauty {
 
@@ -28,10 +37,25 @@ class Server {
                     const Settings &settings,
                     size_t maxContentSize = 1024);
 
+    // Simple constructor with SSL/TLS support.
+    explicit Server(asio::io_context &ioContext,
+                    uint16_t port,
+                    asio::ssl::context &sslCtx,
+                    const Settings &settings,
+                    size_t maxContentSize = 1024);
+
     // Advanced constructor use for OS:s supporting signal_set.
     explicit Server(asio::io_context &ioContext,
                     const std::string &address,
                     const std::string &port,
+                    const Settings &settings,
+                    size_t maxContentSize = 1024);
+
+    // Advanced constructor with SSL/TLS support.
+    explicit Server(asio::io_context &ioContext,
+                    const std::string &address,
+                    const std::string &port,
+                    asio::ssl::context &sslCtx,
                     const Settings &settings,
                     size_t maxContentSize = 1024);
     ~Server() = default;
@@ -51,7 +75,9 @@ class Server {
     void doTick();
 
     std::shared_ptr<asio::signal_set> signals_;
+    asio::io_context &ioContext_;
     asio::ip::tcp::acceptor acceptor_;
+    asio::ssl::context *sslCtx_ = nullptr;
     ConnectionManager connectionManager_;
     RequestHandler requestHandler_;
 

--- a/src/beauty/server.hpp
+++ b/src/beauty/server.hpp
@@ -28,45 +28,45 @@ namespace beauty {
 
 class Server {
    public:
-    Server(const Server &) = delete;
-    Server &operator=(const Server &) = delete;
+    Server(const Server&) = delete;
+    Server& operator=(const Server&) = delete;
 
     // Simple constructor, use for ESP32.
-    explicit Server(asio::io_context &ioContext,
+    explicit Server(asio::io_context& ioContext,
                     uint16_t port,
-                    const Settings &settings,
+                    const Settings& settings,
                     size_t maxContentSize = 1024);
 
     // Simple constructor with SSL/TLS support.
-    explicit Server(asio::io_context &ioContext,
+    explicit Server(asio::io_context& ioContext,
                     uint16_t port,
-                    asio::ssl::context &sslCtx,
-                    const Settings &settings,
+                    asio::ssl::context& sslCtx,
+                    const Settings& settings,
                     size_t maxContentSize = 1024);
 
     // Advanced constructor use for OS:s supporting signal_set.
-    explicit Server(asio::io_context &ioContext,
-                    const std::string &address,
-                    const std::string &port,
-                    const Settings &settings,
+    explicit Server(asio::io_context& ioContext,
+                    const std::string& address,
+                    const std::string& port,
+                    const Settings& settings,
                     size_t maxContentSize = 1024);
 
     // Advanced constructor with SSL/TLS support.
-    explicit Server(asio::io_context &ioContext,
-                    const std::string &address,
-                    const std::string &port,
-                    asio::ssl::context &sslCtx,
-                    const Settings &settings,
+    explicit Server(asio::io_context& ioContext,
+                    const std::string& address,
+                    const std::string& port,
+                    asio::ssl::context& sslCtx,
+                    const Settings& settings,
                     size_t maxContentSize = 1024);
     ~Server() = default;
 
     uint16_t getBindedPort() const;
 
     // Handlers to be optionally implemented.
-    void setFileIO(IFileIO *fileIO);
-    void addRequestHandler(const handlerCallback &cb);
-    void setExpectContinueHandler(const handlerCallback &cb);
-    void setDebugMsgHandler(const debugMsgCallback &cb);
+    void setFileIO(IFileIO* fileIO);
+    void addRequestHandler(const handlerCallback& cb);
+    void setExpectContinueHandler(const handlerCallback& cb);
+    void setDebugMsgHandler(const debugMsgCallback& cb);
     void setWsEndpoints(std::set<std::shared_ptr<WsEndpoint>> endpoints);
 
    private:
@@ -75,9 +75,9 @@ class Server {
     void doTick();
 
     std::shared_ptr<asio::signal_set> signals_;
-    asio::io_context &ioContext_;
+    asio::io_context& ioContext_;
     asio::ip::tcp::acceptor acceptor_;
-    asio::ssl::context *sslCtx_ = nullptr;
+    asio::ssl::context* sslCtx_ = nullptr;
     ConnectionManager connectionManager_;
     RequestHandler requestHandler_;
 

--- a/src/beauty/ssl_socket.hpp
+++ b/src/beauty/ssl_socket.hpp
@@ -28,9 +28,13 @@ class SslSocket : public ISocket {
         stream_.next_layer().shutdown(asio::ip::tcp::socket::shutdown_both, ec);
     }
 
-    bool isOpen() const override { return stream_.next_layer().is_open(); }
+    bool isOpen() const override {
+        return stream_.next_layer().is_open();
+    }
 
-    bool needsHandshake() const override { return true; }
+    bool needsHandshake() const override {
+        return true;
+    }
 
     void asyncConnect(const asio::ip::tcp::resolver::results_type& endpoints,
                       ConnectHandler handler) override {
@@ -38,12 +42,14 @@ class SslSocket : public ISocket {
     }
 
     void asyncHandshake(bool isServer, ErrorHandler handler) override {
-        stream_.async_handshake(isServer ? asio::ssl::stream_base::server
-                                         : asio::ssl::stream_base::client,
-                                std::move(handler));
+        stream_.async_handshake(
+            isServer ? asio::ssl::stream_base::server : asio::ssl::stream_base::client,
+            std::move(handler));
     }
 
-    asio::ip::tcp::socket& tcpSocket() override { return stream_.next_layer(); }
+    asio::ip::tcp::socket& tcpSocket() override {
+        return stream_.next_layer();
+    }
 
    private:
     asio::ssl::stream<asio::ip::tcp::socket> stream_;

--- a/src/beauty/ssl_socket.hpp
+++ b/src/beauty/ssl_socket.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include "beauty/i_socket.hpp"
+
+#include <asio/ssl.hpp>
+
+namespace beauty {
+
+// SSL/TLS socket implementation of ISocket. Wraps an asio::ssl::stream over a
+// TCP socket. Only available when the build has SSL support enabled.
+class SslSocket : public ISocket {
+   public:
+    SslSocket(asio::io_context& ioc, asio::ssl::context& sslCtx) : stream_(ioc, sslCtx) {}
+
+    void asyncReadSome(const asio::mutable_buffer& buffer, IoHandler handler) override {
+        stream_.async_read_some(buffer, std::move(handler));
+    }
+
+    void asyncWrite(const std::vector<asio::const_buffer>& buffers, IoHandler handler) override {
+        asio::async_write(stream_, buffers, std::move(handler));
+    }
+
+    void close() override {
+        std::error_code ec;
+        stream_.next_layer().close(ec);
+    }
+
+    void shutdown(std::error_code& ec) override {
+        stream_.next_layer().shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+    }
+
+    bool isOpen() const override { return stream_.next_layer().is_open(); }
+
+    bool needsHandshake() const override { return true; }
+
+    void asyncConnect(const asio::ip::tcp::resolver::results_type& endpoints,
+                      ConnectHandler handler) override {
+        asio::async_connect(stream_.next_layer(), endpoints, std::move(handler));
+    }
+
+    void asyncHandshake(bool isServer, ErrorHandler handler) override {
+        stream_.async_handshake(isServer ? asio::ssl::stream_base::server
+                                         : asio::ssl::stream_base::client,
+                                std::move(handler));
+    }
+
+    asio::ip::tcp::socket& tcpSocket() override { return stream_.next_layer(); }
+
+   private:
+    asio::ssl::stream<asio::ip::tcp::socket> stream_;
+};
+
+}  // namespace beauty

--- a/src/beauty/ssl_socket.hpp
+++ b/src/beauty/ssl_socket.hpp
@@ -19,13 +19,23 @@ class SslSocket : public ISocket {
         asio::async_write(stream_, buffers, std::move(handler));
     }
 
+    void asyncWrite(const asio::const_buffer& buffer, IoHandler handler) override {
+        asio::async_write(stream_, buffer, std::move(handler));
+    }
+
     void close() override {
+        // Send TLS close_notify, then close the underlying TCP socket.
         std::error_code ec;
+        stream_.shutdown(ec);  // SSL shutdown (best-effort, ignore errors)
         stream_.next_layer().close(ec);
     }
 
     void shutdown(std::error_code& ec) override {
-        stream_.next_layer().shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+        // Perform TLS shutdown handshake, then TCP shutdown.
+        stream_.shutdown(ec);
+        if (!ec) {
+            stream_.next_layer().shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+        }
     }
 
     bool isOpen() const override {

--- a/src/beauty/ws_client.hpp
+++ b/src/beauty/ws_client.hpp
@@ -49,49 +49,57 @@ class WsClient : public std::enable_shared_from_this<WsClient> {
         std::chrono::seconds pingInterval = std::chrono::seconds(0);
     };
 
-    WsClient(const WsClient &) = delete;
-    WsClient &operator=(const WsClient &) = delete;
+    WsClient(const WsClient&) = delete;
+    WsClient& operator=(const WsClient&) = delete;
 
-    static std::shared_ptr<WsClient> create(asio::io_context &ioContext,
-                                            IRandom &random,
-                                            IWsClientHandler &handler,
-                                            const Config &config);
+    static std::shared_ptr<WsClient> create(asio::io_context& ioContext,
+                                            IRandom& random,
+                                            IWsClientHandler& handler,
+                                            const Config& config);
 
-    static std::shared_ptr<WsClient> create(asio::io_context &ioContext,
-                                            IRandom &random,
-                                            IWsClientHandler &handler);
+    static std::shared_ptr<WsClient> create(asio::io_context& ioContext,
+                                            IRandom& random,
+                                            IWsClientHandler& handler);
+
+    // Create a WebSocket client with a custom socket (e.g. SslSocket for wss://).
+    static std::shared_ptr<WsClient> create(asio::io_context& ioContext,
+                                            IRandom& random,
+                                            IWsClientHandler& handler,
+                                            const Config& config,
+                                            std::shared_ptr<ISocket> socket);
 
     ~WsClient() = default;
 
     // Start connecting to the given ws:// URL. May be called again to point the
     // client at a different URL (an existing connection is closed first).
-    void connect(const std::string &url);
+    void connect(const std::string& url);
 
     // Send a text frame. Returns SUCCESS if the write was started, otherwise
     // WRITE_IN_PROGRESS or CONNECTION_CLOSED.
-    WriteResult sendText(const std::string &text);
+    WriteResult sendText(const std::string& text);
 
     // Send a binary frame.
-    WriteResult sendBinary(const std::vector<char> &data);
+    WriteResult sendBinary(const std::vector<char>& data);
 
     // Send a ping frame (no-op if not open or a write is already in progress).
     void sendPing();
 
     // Initiate a graceful close. Disables auto-reconnect for this close.
-    void close(uint16_t statusCode = 1000, const std::string &reason = "");
+    void close(uint16_t statusCode = 1000, const std::string& reason = "");
 
     bool isOpen() const {
         return isOpen_;
     }
 
    private:
-    WsClient(asio::io_context &ioContext,
-             IRandom &random,
-             IWsClientHandler &handler,
-             const Config &config);
+    WsClient(asio::io_context& ioContext,
+             IRandom& random,
+             IWsClientHandler& handler,
+             const Config& config,
+             std::shared_ptr<ISocket> socket);
 
     void doResolve();
-    void doConnect(const asio::ip::tcp::resolver::results_type &endpoints);
+    void doConnect(const asio::ip::tcp::resolver::results_type& endpoints);
     void doWriteHandshake();
     void doReadHandshake();
     void processWsBuffer();
@@ -100,19 +108,19 @@ class WsClient : public std::enable_shared_from_this<WsClient> {
     void startPingTimer();
 
     void finishConnection(bool notifyClose);
-    void handleDisconnect(const std::string &error);
+    void handleDisconnect(const std::string& error);
     void scheduleReconnect();
 
     void resetForNewConnection();
 
-    asio::io_context &ioContext_;
+    asio::io_context& ioContext_;
     asio::ip::tcp::resolver resolver_;
-    std::unique_ptr<ISocket> socket_;
+    std::shared_ptr<ISocket> socket_;
     asio::steady_timer reconnectTimer_;
     asio::steady_timer pingTimer_;
 
-    IRandom &random_;
-    IWsClientHandler &handler_;
+    IRandom& random_;
+    IWsClientHandler& handler_;
     Config config_;
 
     // Buffers (fixed maximum size, mirroring the server).
@@ -153,17 +161,27 @@ class WsClient : public std::enable_shared_from_this<WsClient> {
     std::chrono::milliseconds currentReconnectDelay_;
 };
 
-inline std::shared_ptr<WsClient> WsClient::create(asio::io_context &ioContext,
-                                                  IRandom &random,
-                                                  IWsClientHandler &handler,
-                                                  const Config &config) {
-    return std::shared_ptr<WsClient>(new WsClient(ioContext, random, handler, config));
+inline std::shared_ptr<WsClient> WsClient::create(asio::io_context& ioContext,
+                                                  IRandom& random,
+                                                  IWsClientHandler& handler,
+                                                  const Config& config) {
+    return std::shared_ptr<WsClient>(new WsClient(ioContext, random, handler, config,
+        std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
 }
 
-inline std::shared_ptr<WsClient> WsClient::create(asio::io_context &ioContext,
-                                                  IRandom &random,
-                                                  IWsClientHandler &handler) {
-    return std::shared_ptr<WsClient>(new WsClient(ioContext, random, handler, Config()));
+inline std::shared_ptr<WsClient> WsClient::create(asio::io_context& ioContext,
+                                                  IRandom& random,
+                                                  IWsClientHandler& handler) {
+    return std::shared_ptr<WsClient>(new WsClient(ioContext, random, handler, Config(),
+        std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
+}
+
+inline std::shared_ptr<WsClient> WsClient::create(asio::io_context& ioContext,
+                                                  IRandom& random,
+                                                  IWsClientHandler& handler,
+                                                  const Config& config,
+                                                  std::shared_ptr<ISocket> socket) {
+    return std::shared_ptr<WsClient>(new WsClient(ioContext, random, handler, config, socket));
 }
 
 }  // namespace beauty

--- a/src/beauty/ws_client.hpp
+++ b/src/beauty/ws_client.hpp
@@ -165,15 +165,19 @@ inline std::shared_ptr<WsClient> WsClient::create(asio::io_context& ioContext,
                                                   IRandom& random,
                                                   IWsClientHandler& handler,
                                                   const Config& config) {
-    return std::shared_ptr<WsClient>(new WsClient(ioContext, random, handler, config,
-        std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
+    return std::shared_ptr<WsClient>(new WsClient(
+        ioContext, random, handler, config, std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
 }
 
 inline std::shared_ptr<WsClient> WsClient::create(asio::io_context& ioContext,
                                                   IRandom& random,
                                                   IWsClientHandler& handler) {
-    return std::shared_ptr<WsClient>(new WsClient(ioContext, random, handler, Config(),
-        std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
+    return std::shared_ptr<WsClient>(
+        new WsClient(ioContext,
+                     random,
+                     handler,
+                     Config(),
+                     std::shared_ptr<ISocket>(new PlainSocket(ioContext))));
 }
 
 inline std::shared_ptr<WsClient> WsClient::create(asio::io_context& ioContext,

--- a/src/beauty/ws_client.hpp
+++ b/src/beauty/ws_client.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "beauty/i_ws_client_handler.hpp"
+#include "beauty/i_socket.hpp"
 #include "beauty/response.hpp"
 #include "beauty/response_parser.hpp"
 #include "beauty/url_parser.hpp"
@@ -106,7 +107,7 @@ class WsClient : public std::enable_shared_from_this<WsClient> {
 
     asio::io_context &ioContext_;
     asio::ip::tcp::resolver resolver_;
-    asio::ip::tcp::socket socket_;
+    std::unique_ptr<ISocket> socket_;
     asio::steady_timer reconnectTimer_;
     asio::steady_timer pingTimer_;
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -8,7 +8,7 @@
 
 namespace beauty {
 
-Connection::Connection(std::unique_ptr<ISocket> socket,
+Connection::Connection(std::shared_ptr<ISocket> socket,
                        ConnectionManager& manager,
                        RequestHandler& handler,
                        unsigned connectionId,
@@ -386,23 +386,22 @@ void Connection::doReadBody() {
 void Connection::doWriteHeaders() {
     handleConnection();
     auto self(shared_from_this());
-    socket_->asyncWrite(
-        reply_.headerToBuffers(), [this, self](std::error_code ec, std::size_t) {
-            if (!ec) {
-                lastActivityTime_ = std::chrono::steady_clock::now();
+    socket_->asyncWrite(reply_.headerToBuffers(), [this, self](std::error_code ec, std::size_t) {
+        if (!ec) {
+            lastActivityTime_ = std::chrono::steady_clock::now();
 
-                if (!reply_.content_.empty() || reply_.contentPtr_ != nullptr ||
-                    reply_.streamCallback_ != nullptr) {
-                    doWriteReplyContent();
-                } else {
-                    handleWriteCompleted();
-                }
+            if (!reply_.content_.empty() || reply_.contentPtr_ != nullptr ||
+                reply_.streamCallback_ != nullptr) {
+                doWriteReplyContent();
             } else {
-                connectionManager_.debugMsg("doWriteHeaders: " + ec.message() + ':' +
-                                            std::to_string(ec.value()));
-                shutdown();
+                handleWriteCompleted();
             }
-        });
+        } else {
+            connectionManager_.debugMsg("doWriteHeaders: " + ec.message() + ':' +
+                                        std::to_string(ec.value()));
+            shutdown();
+        }
+    });
 }
 
 void Connection::doWriteReplyContent() {
@@ -411,30 +410,29 @@ void Connection::doWriteReplyContent() {
     // Handle streaming callback before writing
     requestHandler_.handleStreamingRead(connectionId_, reply_);
 
-    socket_->asyncWrite(
-        reply_.contentToBuffers(), [this, self](std::error_code ec, std::size_t) {
-            if (!ec) {
-                lastActivityTime_ = std::chrono::steady_clock::now();
+    socket_->asyncWrite(reply_.contentToBuffers(), [this, self](std::error_code ec, std::size_t) {
+        if (!ec) {
+            lastActivityTime_ = std::chrono::steady_clock::now();
 
-                if (reply_.replyPartial_) {
-                    if (reply_.finalPart_) {
-                        handleWriteCompleted();
-                    } else {
-                        if (!reply_.streamCallback_) {
-                            // FileIO streaming
-                            requestHandler_.handleFileIORead(connectionId_, request_, reply_);
-                        }
-                        doWriteReplyContent();
-                    }
-                } else {
+            if (reply_.replyPartial_) {
+                if (reply_.finalPart_) {
                     handleWriteCompleted();
+                } else {
+                    if (!reply_.streamCallback_) {
+                        // FileIO streaming
+                        requestHandler_.handleFileIORead(connectionId_, request_, reply_);
+                    }
+                    doWriteReplyContent();
                 }
             } else {
-                connectionManager_.debugMsg("doWriteReplyContent: " + ec.message() + ':' +
-                                            std::to_string(ec.value()));
-                shutdown();
+                handleWriteCompleted();
             }
-        });
+        } else {
+            connectionManager_.debugMsg("doWriteReplyContent: " + ec.message() + ':' +
+                                        std::to_string(ec.value()));
+            shutdown();
+        }
+    });
 }
 
 void Connection::handleConnection() {
@@ -494,21 +492,20 @@ void Connection::doWrite100Continue() {
     // Create 100 Continue response as shared_ptr to ensure it outlives the async_write.
     auto continueResponse = std::make_shared<std::string>("HTTP/1.1 100 Continue\r\n\r\n");
 
-    socket_->asyncWrite(
-                      {asio::buffer(*continueResponse)},
-                      [this, self, continueResponse](std::error_code ec, std::size_t) {
-                          (void)continueResponse;
-                          if (!ec) {
-                              // Initialize reply for body reading - no body bytes received yet
-                              reply_.noBodyBytesReceived_ = 0;
-                              // Now read the body using special method for 100-continue
-                              doReadBodyAfter100Continue();
-                          } else {
-                              connectionManager_.debugMsg("doWrite100Continue: " + ec.message() +
-                                                          ':' + std::to_string(ec.value()));
-                              shutdown();
-                          }
-                      });
+    socket_->asyncWrite({asio::buffer(*continueResponse)},
+                        [this, self, continueResponse](std::error_code ec, std::size_t) {
+                            (void)continueResponse;
+                            if (!ec) {
+                                // Initialize reply for body reading - no body bytes received yet
+                                reply_.noBodyBytesReceived_ = 0;
+                                // Now read the body using special method for 100-continue
+                                doReadBodyAfter100Continue();
+                            } else {
+                                connectionManager_.debugMsg("doWrite100Continue: " + ec.message() +
+                                                            ':' + std::to_string(ec.value()));
+                                shutdown();
+                            }
+                        });
 }
 
 void Connection::doReadBodyAfter100Continue() {
@@ -588,29 +585,28 @@ void Connection::handleUpgradeToWebSocket() {
 
 void Connection::doAckWsUpgrade() {
     auto self(shared_from_this());
-    socket_->asyncWrite(
-        reply_.headerToBuffers(), [this, self](std::error_code ec, std::size_t) {
-            if (!ec) {
-                requestParser_.reset();
-                request_.reset();
-                reply_.reset();
-                isWebSocket_ = true;
-                connectionManager_.debugMsg("WebSocket upgraded on path: " + request_.requestPath_);
-                if (wsEndpoint_) {
-                    wsEndpoint_->onWsOpen(std::to_string(connectionId_));
-                }
-                doRead();
-            } else {
-                connectionManager_.debugMsg("doAckWsUpgrade: " + ec.message() + ':' +
-                                            std::to_string(ec.value()));
-                // Notify WebSocket endpoint of upgrade failure
-                if (wsEndpoint_) {
-                    wsEndpoint_->onWsError(std::to_string(connectionId_),
-                                           "WebSocket upgrade failed: " + ec.message());
-                }
-                shutdown();
+    socket_->asyncWrite(reply_.headerToBuffers(), [this, self](std::error_code ec, std::size_t) {
+        if (!ec) {
+            requestParser_.reset();
+            request_.reset();
+            reply_.reset();
+            isWebSocket_ = true;
+            connectionManager_.debugMsg("WebSocket upgraded on path: " + request_.requestPath_);
+            if (wsEndpoint_) {
+                wsEndpoint_->onWsOpen(std::to_string(connectionId_));
             }
-        });
+            doRead();
+        } else {
+            connectionManager_.debugMsg("doAckWsUpgrade: " + ec.message() + ':' +
+                                        std::to_string(ec.value()));
+            // Notify WebSocket endpoint of upgrade failure
+            if (wsEndpoint_) {
+                wsEndpoint_->onWsError(std::to_string(connectionId_),
+                                       "WebSocket upgrade failed: " + ec.message());
+            }
+            shutdown();
+        }
+    });
 }
 
 void Connection::doWriteWsFrame(bool continueReading, WriteCompleteCallback callback) {
@@ -621,32 +617,31 @@ void Connection::doWriteWsFrame(bool continueReading, WriteCompleteCallback call
     std::vector<asio::const_buffer> buffers;
     buffers.push_back(asio::buffer(sendBuffer_));
     socket_->asyncWrite(
-                      buffers,
-                      [this, self, continueReading](std::error_code ec, std::size_t bytesWritten) {
-                          writeInProgress_ = false;
+        buffers, [this, self, continueReading](std::error_code ec, std::size_t bytesWritten) {
+            writeInProgress_ = false;
 
-                          if (!ec) {
-                              lastActivityTime_ = std::chrono::steady_clock::now();
-                              if (continueReading) {
-                                  doRead();  // Continue reading after write completes
-                              }
-                          } else {
-                              connectionManager_.debugMsg("doWriteWsFrame: " + ec.message() + ':' +
-                                                          std::to_string(ec.value()));
-                              // Notify WebSocket endpoint of write error
-                              if (wsEndpoint_) {
-                                  wsEndpoint_->onWsError(std::to_string(connectionId_),
-                                                         "Write error: " + ec.message());
-                              }
-                              shutdown();
-                          }
+            if (!ec) {
+                lastActivityTime_ = std::chrono::steady_clock::now();
+                if (continueReading) {
+                    doRead();  // Continue reading after write completes
+                }
+            } else {
+                connectionManager_.debugMsg("doWriteWsFrame: " + ec.message() + ':' +
+                                            std::to_string(ec.value()));
+                // Notify WebSocket endpoint of write error
+                if (wsEndpoint_) {
+                    wsEndpoint_->onWsError(std::to_string(connectionId_),
+                                           "Write error: " + ec.message());
+                }
+                shutdown();
+            }
 
-                          // Call completion callback if provided
-                          if (writeCallback_) {
-                              writeCallback_(ec, bytesWritten);
-                              writeCallback_ = nullptr;
-                          }
-                      });
+            // Call completion callback if provided
+            if (writeCallback_) {
+                writeCallback_(ec, bytesWritten);
+                writeCallback_ = nullptr;
+            }
+        });
 }
 
 void Connection::shutdown() {

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -492,7 +492,7 @@ void Connection::doWrite100Continue() {
     // Create 100 Continue response as shared_ptr to ensure it outlives the async_write.
     auto continueResponse = std::make_shared<std::string>("HTTP/1.1 100 Continue\r\n\r\n");
 
-    socket_->asyncWrite({asio::buffer(*continueResponse)},
+    socket_->asyncWrite(asio::buffer(*continueResponse),
                         [this, self, continueResponse](std::error_code ec, std::size_t) {
                             (void)continueResponse;
                             if (!ec) {

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -8,7 +8,7 @@
 
 namespace beauty {
 
-Connection::Connection(asio::ip::tcp::socket socket,
+Connection::Connection(std::unique_ptr<ISocket> socket,
                        ConnectionManager& manager,
                        RequestHandler& handler,
                        unsigned connectionId,
@@ -35,11 +35,24 @@ void Connection::start(bool useKeepAlive,
     useKeepAlive_ = useKeepAlive;
     keepAliveTimeout_ = keepAliveTimeout;
     keepAliveMax_ = keepAliveMax;
-    doRead();
+
+    if (socket_->needsHandshake()) {
+        auto self(shared_from_this());
+        socket_->asyncHandshake(true, [this, self](const std::error_code& ec) {
+            if (!ec) {
+                doRead();
+            } else {
+                connectionManager_.debugMsg("Handshake failed: " + ec.message());
+                connectionManager_.stop(shared_from_this());
+            }
+        });
+    } else {
+        doRead();
+    }
 }
 
 void Connection::stop() {
-    socket_.close();
+    socket_->close();
 }
 
 std::chrono::steady_clock::time_point Connection::getLastActivityTime() const {
@@ -152,7 +165,7 @@ void Connection::doRead() {
         }
         size_t readSize = maxContentSize_ - wsParseOffset_;
         recvBuffer_.resize(wsParseOffset_ + readSize);
-        socket_.async_read_some(
+        socket_->asyncReadSome(
             asio::buffer(recvBuffer_.data() + wsParseOffset_, readSize),
             [this, self](std::error_code ec, std::size_t bytesTransferred) {
                 if (!ec) {
@@ -217,7 +230,7 @@ void Connection::doRead() {
 
     // HTTP path — read into the full buffer from position 0.
     recvBuffer_.resize(maxContentSize_);
-    socket_.async_read_some(
+    socket_->asyncReadSome(
         asio::buffer(recvBuffer_), [this, self](std::error_code ec, std::size_t bytesTransferred) {
             if (!ec) {
                 lastActivityTime_ = std::chrono::steady_clock::now();
@@ -337,7 +350,7 @@ void Connection::doRead() {
 void Connection::doReadBody() {
     recvBuffer_.resize(maxContentSize_);
     auto self(shared_from_this());
-    socket_.async_read_some(
+    socket_->asyncReadSome(
         asio::buffer(recvBuffer_), [this, self](std::error_code ec, std::size_t bytesTransferred) {
             if (!ec) {
                 lastActivityTime_ = std::chrono::steady_clock::now();
@@ -373,8 +386,8 @@ void Connection::doReadBody() {
 void Connection::doWriteHeaders() {
     handleConnection();
     auto self(shared_from_this());
-    asio::async_write(
-        socket_, reply_.headerToBuffers(), [this, self](std::error_code ec, std::size_t) {
+    socket_->asyncWrite(
+        reply_.headerToBuffers(), [this, self](std::error_code ec, std::size_t) {
             if (!ec) {
                 lastActivityTime_ = std::chrono::steady_clock::now();
 
@@ -398,8 +411,8 @@ void Connection::doWriteReplyContent() {
     // Handle streaming callback before writing
     requestHandler_.handleStreamingRead(connectionId_, reply_);
 
-    asio::async_write(
-        socket_, reply_.contentToBuffers(), [this, self](std::error_code ec, std::size_t) {
+    socket_->asyncWrite(
+        reply_.contentToBuffers(), [this, self](std::error_code ec, std::size_t) {
             if (!ec) {
                 lastActivityTime_ = std::chrono::steady_clock::now();
 
@@ -470,7 +483,7 @@ void Connection::handleWriteCompleted() {
     } else {
         // Initiate graceful connection closure
         std::error_code ignored_ec;
-        socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ignored_ec);
+        socket_->shutdown(ignored_ec);
         connectionManager_.stop(shared_from_this());
     }
 }
@@ -481,8 +494,8 @@ void Connection::doWrite100Continue() {
     // Create 100 Continue response as shared_ptr to ensure it outlives the async_write.
     auto continueResponse = std::make_shared<std::string>("HTTP/1.1 100 Continue\r\n\r\n");
 
-    asio::async_write(socket_,
-                      asio::buffer(*continueResponse),
+    socket_->asyncWrite(
+                      {asio::buffer(*continueResponse)},
                       [this, self, continueResponse](std::error_code ec, std::size_t) {
                           (void)continueResponse;
                           if (!ec) {
@@ -501,7 +514,7 @@ void Connection::doWrite100Continue() {
 void Connection::doReadBodyAfter100Continue() {
     recvBuffer_.resize(maxContentSize_);
     auto self(shared_from_this());
-    socket_.async_read_some(
+    socket_->asyncReadSome(
         asio::buffer(recvBuffer_), [this, self](std::error_code ec, std::size_t bytesTransferred) {
             if (!ec) {
                 lastActivityTime_ = std::chrono::steady_clock::now();
@@ -575,8 +588,8 @@ void Connection::handleUpgradeToWebSocket() {
 
 void Connection::doAckWsUpgrade() {
     auto self(shared_from_this());
-    asio::async_write(
-        socket_, reply_.headerToBuffers(), [this, self](std::error_code ec, std::size_t) {
+    socket_->asyncWrite(
+        reply_.headerToBuffers(), [this, self](std::error_code ec, std::size_t) {
             if (!ec) {
                 requestParser_.reset();
                 request_.reset();
@@ -607,7 +620,7 @@ void Connection::doWriteWsFrame(bool continueReading, WriteCompleteCallback call
     auto self(shared_from_this());
     std::vector<asio::const_buffer> buffers;
     buffers.push_back(asio::buffer(sendBuffer_));
-    asio::async_write(socket_,
+    socket_->asyncWrite(
                       buffers,
                       [this, self, continueReading](std::error_code ec, std::size_t bytesWritten) {
                           writeInProgress_ = false;
@@ -639,7 +652,7 @@ void Connection::doWriteWsFrame(bool continueReading, WriteCompleteCallback call
 void Connection::shutdown() {
     // Initiate graceful connection closure
     std::error_code ignored_ec;
-    socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ignored_ec);
+    socket_->shutdown(ignored_ec);
     connectionManager_.stop(shared_from_this());
     requestHandler_.closeFile(connectionId_);
 }

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -322,7 +322,6 @@ void HttpClient::close() {
 }
 
 void HttpClient::closeSocket() {
-    std::error_code ignore;
     resolver_.cancel();
     socket_->close();
     connected_ = false;

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -225,7 +225,7 @@ void HttpClient::doWriteRequest() {
     writeBuffer_.insert(writeBuffer_.end(), sendBuffer_.begin(), sendBuffer_.end());
 
     auto self(shared_from_this());
-    socket_->asyncWrite({asio::buffer(writeBuffer_)},
+    socket_->asyncWrite(asio::buffer(writeBuffer_),
                         [this, self](const std::error_code& ec, std::size_t) {
                             if (ec) {
                                 // A keep-alive connection may have been closed by the server

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -5,18 +5,21 @@
 
 namespace beauty {
 
-HttpClient::HttpClient(asio::io_context &ioContext,
-                       IHttpClientHandler &handler,
-                       const Config &config,
-                       std::unique_ptr<ISocket> socket)
+HttpClient::HttpClient(asio::io_context& ioContext,
+                       IHttpClientHandler& handler,
+                       const Config& config,
+                       std::shared_ptr<ISocket> socket)
     : ioContext_(ioContext),
       resolver_(ioContext),
-      socket_(std::move(socket)),
+      socket_(socket),
       timeoutTimer_(ioContext),
       handler_(handler),
       config_(config),
       response_(bodyBuffer_),
       responseParser_() {
+    if (!socket_) {
+        socket_.reset(new PlainSocket(ioContext));
+    }
     // Default maxRequestBodySize to maxResponseSize when left at 0.
     if (config_.maxRequestBodySize == 0) {
         config_.maxRequestBodySize = config_.maxResponseSize;
@@ -34,10 +37,10 @@ HttpClient::HttpClient(asio::io_context &ioContext,
     responseParser_.setMaxBodySize(config_.maxResponseSize);
 }
 
-bool HttpClient::request(const std::string &method,
-                         const std::string &url,
-                         const std::vector<Header> &headers,
-                         const std::string &body) {
+bool HttpClient::request(const std::string& method,
+                         const std::string& url,
+                         const std::vector<Header>& headers,
+                         const std::string& body) {
     if (requestInProgress_) {
         return false;
     }
@@ -84,7 +87,7 @@ bool HttpClient::request(const std::string &method,
     req += method_ + " " + target + " HTTP/1.1\r\n";
     req += "Host: " + host_ + ":" + port_ + "\r\n";
     req += std::string("Connection: ") + (config_.keepAlive ? "keep-alive" : "close") + "\r\n";
-    for (const Header &h : headers) {
+    for (const Header& h : headers) {
         req += h.name_ + ": " + h.value_ + "\r\n";
     }
     if (!body.empty()) {
@@ -101,31 +104,31 @@ bool HttpClient::request(const std::string &method,
     return true;
 }
 
-bool HttpClient::get(const std::string &url, const std::vector<Header> &headers) {
+bool HttpClient::get(const std::string& url, const std::vector<Header>& headers) {
     return request("GET", url, headers, std::string());
 }
 
-bool HttpClient::head(const std::string &url, const std::vector<Header> &headers) {
+bool HttpClient::head(const std::string& url, const std::vector<Header>& headers) {
     return request("HEAD", url, headers, std::string());
 }
 
-bool HttpClient::del(const std::string &url, const std::vector<Header> &headers) {
+bool HttpClient::del(const std::string& url, const std::vector<Header>& headers) {
     return request("DELETE", url, headers, std::string());
 }
 
-bool HttpClient::post(const std::string &url,
-                      const std::string &contentType,
-                      const std::string &body,
-                      const std::vector<Header> &headers) {
+bool HttpClient::post(const std::string& url,
+                      const std::string& contentType,
+                      const std::string& body,
+                      const std::vector<Header>& headers) {
     std::vector<Header> all = headers;
     all.push_back(Header{"Content-Type", contentType});
     return request("POST", url, all, body);
 }
 
-bool HttpClient::put(const std::string &url,
-                     const std::string &contentType,
-                     const std::string &body,
-                     const std::vector<Header> &headers) {
+bool HttpClient::put(const std::string& url,
+                     const std::string& contentType,
+                     const std::string& body,
+                     const std::vector<Header>& headers) {
     std::vector<Header> all = headers;
     all.push_back(Header{"Content-Type", contentType});
     return request("PUT", url, all, body);
@@ -156,7 +159,7 @@ void HttpClient::startTimeoutTimer() {
     }
     auto self(shared_from_this());
     timeoutTimer_.expires_after(config_.requestTimeout);
-    timeoutTimer_.async_wait([this, self](const std::error_code &ec) {
+    timeoutTimer_.async_wait([this, self](const std::error_code& ec) {
         if (!ec && requestInProgress_) {
             reportError("Request timed out");
         }
@@ -167,8 +170,8 @@ void HttpClient::doResolve() {
     auto self(shared_from_this());
     resolver_.async_resolve(host_,
                             port_,
-                            [this, self](const std::error_code &ec,
-                                         const asio::ip::tcp::resolver::results_type &endpoints) {
+                            [this, self](const std::error_code& ec,
+                                         const asio::ip::tcp::resolver::results_type& endpoints) {
                                 if (!requestInProgress_) {
                                     return;
                                 }
@@ -180,28 +183,27 @@ void HttpClient::doResolve() {
                             });
 }
 
-void HttpClient::doConnect(const asio::ip::tcp::resolver::results_type &endpoints) {
+void HttpClient::doConnect(const asio::ip::tcp::resolver::results_type& endpoints) {
     auto self(shared_from_this());
-    socket_->asyncConnect(
-                        endpoints,
-                        [this, self](const std::error_code &ec, const asio::ip::tcp::endpoint &) {
-                            if (!requestInProgress_) {
-                                return;
-                            }
-                            if (ec) {
-                                reportError("Connect failed: " + ec.message());
-                                return;
-                            }
-                            connected_ = true;
-                            connectedHost_ = host_;
-                            connectedPort_ = port_;
-                            doHandshake();
-                        });
+    socket_->asyncConnect(endpoints,
+                          [this, self](const std::error_code& ec, const asio::ip::tcp::endpoint&) {
+                              if (!requestInProgress_) {
+                                  return;
+                              }
+                              if (ec) {
+                                  reportError("Connect failed: " + ec.message());
+                                  return;
+                              }
+                              connected_ = true;
+                              connectedHost_ = host_;
+                              connectedPort_ = port_;
+                              doHandshake();
+                          });
 }
 
 void HttpClient::doHandshake() {
     auto self(shared_from_this());
-    socket_->asyncHandshake(false, [this, self](const std::error_code &ec) {
+    socket_->asyncHandshake(false, [this, self](const std::error_code& ec) {
         if (!requestInProgress_) {
             return;
         }
@@ -223,16 +225,16 @@ void HttpClient::doWriteRequest() {
     writeBuffer_.insert(writeBuffer_.end(), sendBuffer_.begin(), sendBuffer_.end());
 
     auto self(shared_from_this());
-    socket_->asyncWrite(
-        {asio::buffer(writeBuffer_)}, [this, self](const std::error_code &ec, std::size_t) {
-            if (ec) {
-                // A keep-alive connection may have been closed by the server
-                // between requests; surface it as an error.
-                reportError("Write failed: " + ec.message());
-                return;
-            }
-            doReadResponse();
-        });
+    socket_->asyncWrite({asio::buffer(writeBuffer_)},
+                        [this, self](const std::error_code& ec, std::size_t) {
+                            if (ec) {
+                                // A keep-alive connection may have been closed by the server
+                                // between requests; surface it as an error.
+                                reportError("Write failed: " + ec.message());
+                                return;
+                            }
+                            doReadResponse();
+                        });
 }
 
 void HttpClient::doReadResponse() {
@@ -240,7 +242,7 @@ void HttpClient::doReadResponse() {
     recvBuffer_.resize(config_.maxResponseSize);
     socket_->asyncReadSome(
         asio::buffer(recvBuffer_),
-        [this, self](const std::error_code &ec, std::size_t bytesTransferred) {
+        [this, self](const std::error_code& ec, std::size_t bytesTransferred) {
             if (ec) {
                 if (ec == asio::error::eof || ec == asio::error::connection_reset) {
                     // The server closed the connection. If the body was
@@ -302,7 +304,7 @@ void HttpClient::deliverResponse() {
     handler_.onResponse(snapshot);
 }
 
-void HttpClient::reportError(const std::string &error) {
+void HttpClient::reportError(const std::string& error) {
     if (!requestInProgress_) {
         return;
     }
@@ -328,7 +330,7 @@ void HttpClient::closeSocket() {
     connectedPort_.clear();
 }
 
-bool HttpClient::sameTarget(const std::string &host, const std::string &port) const {
+bool HttpClient::sameTarget(const std::string& host, const std::string& port) const {
     return connectedHost_ == host && connectedPort_ == port;
 }
 

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -7,10 +7,11 @@ namespace beauty {
 
 HttpClient::HttpClient(asio::io_context &ioContext,
                        IHttpClientHandler &handler,
-                       const Config &config)
+                       const Config &config,
+                       std::unique_ptr<ISocket> socket)
     : ioContext_(ioContext),
       resolver_(ioContext),
-      socket_(ioContext),
+      socket_(std::move(socket)),
       timeoutTimer_(ioContext),
       handler_(handler),
       config_(config),
@@ -141,7 +142,7 @@ void HttpClient::startRequest() {
     startTimeoutTimer();
 
     // Reuse an existing keep-alive connection to the same target if possible.
-    if (connected_ && socket_.is_open() && sameTarget(host_, port_)) {
+    if (connected_ && socket_->isOpen() && sameTarget(host_, port_)) {
         doWriteRequest();
     } else {
         closeSocket();
@@ -181,7 +182,7 @@ void HttpClient::doResolve() {
 
 void HttpClient::doConnect(const asio::ip::tcp::resolver::results_type &endpoints) {
     auto self(shared_from_this());
-    asio::async_connect(socket_,
+    socket_->asyncConnect(
                         endpoints,
                         [this, self](const std::error_code &ec, const asio::ip::tcp::endpoint &) {
                             if (!requestInProgress_) {
@@ -194,8 +195,22 @@ void HttpClient::doConnect(const asio::ip::tcp::resolver::results_type &endpoint
                             connected_ = true;
                             connectedHost_ = host_;
                             connectedPort_ = port_;
-                            doWriteRequest();
+                            doHandshake();
                         });
+}
+
+void HttpClient::doHandshake() {
+    auto self(shared_from_this());
+    socket_->asyncHandshake(false, [this, self](const std::error_code &ec) {
+        if (!requestInProgress_) {
+            return;
+        }
+        if (ec) {
+            reportError("TLS handshake failed: " + ec.message());
+            return;
+        }
+        doWriteRequest();
+    });
 }
 
 void HttpClient::doWriteRequest() {
@@ -208,8 +223,8 @@ void HttpClient::doWriteRequest() {
     writeBuffer_.insert(writeBuffer_.end(), sendBuffer_.begin(), sendBuffer_.end());
 
     auto self(shared_from_this());
-    asio::async_write(
-        socket_, asio::buffer(writeBuffer_), [this, self](const std::error_code &ec, std::size_t) {
+    socket_->asyncWrite(
+        {asio::buffer(writeBuffer_)}, [this, self](const std::error_code &ec, std::size_t) {
             if (ec) {
                 // A keep-alive connection may have been closed by the server
                 // between requests; surface it as an error.
@@ -223,7 +238,7 @@ void HttpClient::doWriteRequest() {
 void HttpClient::doReadResponse() {
     auto self(shared_from_this());
     recvBuffer_.resize(config_.maxResponseSize);
-    socket_.async_read_some(
+    socket_->asyncReadSome(
         asio::buffer(recvBuffer_),
         [this, self](const std::error_code &ec, std::size_t bytesTransferred) {
             if (ec) {
@@ -307,7 +322,7 @@ void HttpClient::close() {
 void HttpClient::closeSocket() {
     std::error_code ignore;
     resolver_.cancel();
-    socket_.close(ignore);
+    socket_->close();
     connected_ = false;
     connectedHost_.clear();
     connectedPort_.clear();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -33,6 +33,8 @@ Server::Server(asio::io_context& ioContext,
       debugMsgCb_(defaultDebugMsgHandler) {
     if (maxContentSize < 1024) {
         debugMsgCb_("maxContentSize must be equal or larger than 1024 bytes");
+        std::error_code ec;
+        acceptor_.close(ec);
         return;
     }
     doAccept();
@@ -52,8 +54,16 @@ Server::Server(asio::io_context& ioContext,
       timer_(ioContext),
       maxContentSize_(maxContentSize),
       debugMsgCb_(defaultDebugMsgHandler) {
+#ifndef BEAUTY_HAS_SSL
+    debugMsgCb_("SSL/TLS support is not compiled in — refusing to serve plaintext on a TLS port");
+    std::error_code ec;
+    acceptor_.close(ec);
+    return;
+#endif
     if (maxContentSize < 1024) {
         debugMsgCb_("maxContentSize must be equal or larger than 1024 bytes");
+        std::error_code ec;
+        acceptor_.close(ec);
         return;
     }
     doAccept();
@@ -84,6 +94,8 @@ Server::Server(asio::io_context& ioContext,
 
     if (maxContentSize < 1024) {
         debugMsgCb_("maxContentSize must be equal or larger than 1024 bytes");
+        std::error_code ec;
+        acceptor_.close(ec);
         return;
     }
     doAwaitStop();
@@ -122,8 +134,17 @@ Server::Server(asio::io_context& ioContext,
     signals_->add(SIGQUIT);
 #endif
 
+#ifndef BEAUTY_HAS_SSL
+    debugMsgCb_("SSL/TLS support is not compiled in — refusing to serve plaintext on a TLS port");
+    std::error_code ec;
+    acceptor_.close(ec);
+    return;
+#endif
+
     if (maxContentSize < 1024) {
         debugMsgCb_("maxContentSize must be equal or larger than 1024 bytes");
+        std::error_code ec;
+        acceptor_.close(ec);
         return;
     }
     doAwaitStop();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -197,11 +197,8 @@ void Server::doAccept() {
                 return;
             }
             if (!ec) {
-                connectionManager_.start(std::make_shared<Connection>(sock,
-                                                                      connectionManager_,
-                                                                      requestHandler_,
-                                                                      connectionId_++,
-                                                                      maxContentSize_));
+                connectionManager_.start(std::make_shared<Connection>(
+                    sock, connectionManager_, requestHandler_, connectionId_++, maxContentSize_));
             } else {
                 debugMsgCb_("doAccept(ssl): " + ec.message() + ":" + std::to_string(ec.value()));
             }
@@ -216,11 +213,8 @@ void Server::doAccept() {
         }
         if (!ec) {
             std::shared_ptr<ISocket> sock(new PlainSocket(std::move(socket)));
-            connectionManager_.start(std::make_shared<Connection>(sock,
-                                                                  connectionManager_,
-                                                                  requestHandler_,
-                                                                  connectionId_++,
-                                                                  maxContentSize_));
+            connectionManager_.start(std::make_shared<Connection>(
+                sock, connectionManager_, requestHandler_, connectionId_++, maxContentSize_));
         } else {
             debugMsgCb_("doAccept: " + ec.message() + ":" + std::to_string(ec.value()));
         }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -7,21 +7,22 @@
 #include "beauty/ws_endpoint.hpp"
 
 // SslSocket requires <asio/ssl.hpp> which is only available when SSL support
-// is enabled. On ESP-IDF this is gated by CONFIG_ASIO_SSL_SUPPORT.
-#if defined(CONFIG_ASIO_SSL_SUPPORT) || defined(BEAUTY_ENABLE_SSL) || defined(ASIO_SSL_HPP)
+// is enabled. On ESP-IDF this is gated by CONFIG_ASIO_SSL_SUPPORT. On PC
+// builds, CMakeLists.txt defines BEAUTY_ENABLE_SSL when OpenSSL is found.
+#if defined(CONFIG_ASIO_SSL_SUPPORT) || defined(BEAUTY_ENABLE_SSL)
 #include "beauty/ssl_socket.hpp"
 #define BEAUTY_HAS_SSL 1
 #endif
 
 namespace {
-void defaultDebugMsgHandler(const std::string &) {}
+void defaultDebugMsgHandler(const std::string&) {}
 }
 
 namespace beauty {
 
-Server::Server(asio::io_context &ioContext,
+Server::Server(asio::io_context& ioContext,
                uint16_t port,
-               const Settings &settings,
+               const Settings& settings,
                size_t maxContentSize)
     : ioContext_(ioContext),
       acceptor_(ioContext, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port)),
@@ -38,10 +39,10 @@ Server::Server(asio::io_context &ioContext,
     doTick();
 }
 
-Server::Server(asio::io_context &ioContext,
+Server::Server(asio::io_context& ioContext,
                uint16_t port,
-               asio::ssl::context &sslCtx,
-               const Settings &settings,
+               asio::ssl::context& sslCtx,
+               const Settings& settings,
                size_t maxContentSize)
     : ioContext_(ioContext),
       acceptor_(ioContext, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port)),
@@ -59,10 +60,10 @@ Server::Server(asio::io_context &ioContext,
     doTick();
 }
 
-Server::Server(asio::io_context &ioContext,
-               const std::string &address,
-               const std::string &port,
-               const Settings &settings,
+Server::Server(asio::io_context& ioContext,
+               const std::string& address,
+               const std::string& port,
+               const Settings& settings,
                size_t maxContentSize)
     : ioContext_(ioContext),
       acceptor_(ioContext),
@@ -100,11 +101,11 @@ Server::Server(asio::io_context &ioContext,
     doTick();
 }
 
-Server::Server(asio::io_context &ioContext,
-               const std::string &address,
-               const std::string &port,
-               asio::ssl::context &sslCtx,
-               const Settings &settings,
+Server::Server(asio::io_context& ioContext,
+               const std::string& address,
+               const std::string& port,
+               asio::ssl::context& sslCtx,
+               const Settings& settings,
                size_t maxContentSize)
     : ioContext_(ioContext),
       acceptor_(ioContext),
@@ -142,15 +143,15 @@ uint16_t Server::getBindedPort() const {
     return acceptor_.local_endpoint().port();
 }
 
-void Server::setFileIO(IFileIO *fileIO) {
+void Server::setFileIO(IFileIO* fileIO) {
     requestHandler_.setFileIO(fileIO);
 }
 
-void Server::addRequestHandler(const handlerCallback &cb) {
+void Server::addRequestHandler(const handlerCallback& cb) {
     requestHandler_.addRequestHandler(cb);
 }
 
-void Server::setExpectContinueHandler(const handlerCallback &cb) {
+void Server::setExpectContinueHandler(const handlerCallback& cb) {
     requestHandler_.setExpectContinueHandler(cb);
 }
 
@@ -158,7 +159,7 @@ void Server::setWsEndpoints(std::set<std::shared_ptr<WsEndpoint>> endpoints) {
     connectionManager_.setWsEndpoints(endpoints);
 }
 
-void Server::setDebugMsgHandler(const debugMsgCallback &cb) {
+void Server::setDebugMsgHandler(const debugMsgCallback& cb) {
     connectionManager_.setDebugMsgHandler(cb);
     debugMsgCb_ = cb;
 }
@@ -169,26 +170,22 @@ void Server::doAccept() {
         // SSL accept: pre-create the SslSocket so we can accept on its
         // underlying TCP socket, then let Connection::start() perform the
         // TLS handshake before the first read.
-        auto sock = std::unique_ptr<SslSocket>(new SslSocket(ioContext_, *sslCtx_));
-        auto *rawTcp = &sock->tcpSocket();
-        acceptor_.async_accept(
-            *rawTcp,
-            [this, sock = std::move(sock)](std::error_code ec) mutable {
-                if (!acceptor_.is_open()) {
-                    return;
-                }
-                if (!ec) {
-                    connectionManager_.start(std::make_shared<Connection>(std::move(sock),
-                                                                         connectionManager_,
-                                                                         requestHandler_,
-                                                                         connectionId_++,
-                                                                         maxContentSize_));
-                } else {
-                    debugMsgCb_("doAccept(ssl): " + ec.message() + ":" +
-                                std::to_string(ec.value()));
-                }
-                doAccept();
-            });
+        std::shared_ptr<ISocket> sock(new SslSocket(ioContext_, *sslCtx_));
+        acceptor_.async_accept(sock->tcpSocket(), [this, sock](std::error_code ec) {
+            if (!acceptor_.is_open()) {
+                return;
+            }
+            if (!ec) {
+                connectionManager_.start(std::make_shared<Connection>(sock,
+                                                                      connectionManager_,
+                                                                      requestHandler_,
+                                                                      connectionId_++,
+                                                                      maxContentSize_));
+            } else {
+                debugMsgCb_("doAccept(ssl): " + ec.message() + ":" + std::to_string(ec.value()));
+            }
+            doAccept();
+        });
         return;
     }
 #endif
@@ -197,8 +194,8 @@ void Server::doAccept() {
             return;
         }
         if (!ec) {
-            auto sock = std::unique_ptr<PlainSocket>(new PlainSocket(std::move(socket)));
-            connectionManager_.start(std::make_shared<Connection>(std::move(sock),
+            std::shared_ptr<ISocket> sock(new PlainSocket(std::move(socket)));
+            connectionManager_.start(std::make_shared<Connection>(sock,
                                                                   connectionManager_,
                                                                   requestHandler_,
                                                                   connectionId_++,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3,7 +3,15 @@
 #include <utility>
 
 #include "beauty/server.hpp"
+#include "beauty/i_socket.hpp"
 #include "beauty/ws_endpoint.hpp"
+
+// SslSocket requires <asio/ssl.hpp> which is only available when SSL support
+// is enabled. On ESP-IDF this is gated by CONFIG_ASIO_SSL_SUPPORT.
+#if defined(CONFIG_ASIO_SSL_SUPPORT) || defined(BEAUTY_ENABLE_SSL) || defined(ASIO_SSL_HPP)
+#include "beauty/ssl_socket.hpp"
+#define BEAUTY_HAS_SSL 1
+#endif
 
 namespace {
 void defaultDebugMsgHandler(const std::string &) {}
@@ -15,7 +23,29 @@ Server::Server(asio::io_context &ioContext,
                uint16_t port,
                const Settings &settings,
                size_t maxContentSize)
-    : acceptor_(ioContext, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port)),
+    : ioContext_(ioContext),
+      acceptor_(ioContext, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port)),
+      connectionManager_(settings),
+      requestHandler_(maxContentSize),
+      timer_(ioContext),
+      maxContentSize_(maxContentSize),
+      debugMsgCb_(defaultDebugMsgHandler) {
+    if (maxContentSize < 1024) {
+        debugMsgCb_("maxContentSize must be equal or larger than 1024 bytes");
+        return;
+    }
+    doAccept();
+    doTick();
+}
+
+Server::Server(asio::io_context &ioContext,
+               uint16_t port,
+               asio::ssl::context &sslCtx,
+               const Settings &settings,
+               size_t maxContentSize)
+    : ioContext_(ioContext),
+      acceptor_(ioContext, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port)),
+      sslCtx_(&sslCtx),
       connectionManager_(settings),
       requestHandler_(maxContentSize),
       timer_(ioContext),
@@ -34,7 +64,8 @@ Server::Server(asio::io_context &ioContext,
                const std::string &port,
                const Settings &settings,
                size_t maxContentSize)
-    : acceptor_(ioContext),
+    : ioContext_(ioContext),
+      acceptor_(ioContext),
       connectionManager_(settings),
       requestHandler_(maxContentSize),
       timer_(ioContext),
@@ -58,6 +89,44 @@ Server::Server(asio::io_context &ioContext,
 
     // Open the acceptor with the option to reuse the address (i.e.
     // SO_REUSEADDR).
+    asio::ip::tcp::resolver resolver(ioContext);
+    asio::ip::tcp::endpoint endpoint = *resolver.resolve(address, port).begin();
+    acceptor_.open(endpoint.protocol());
+    acceptor_.set_option(asio::ip::tcp::acceptor::reuse_address(true));
+    acceptor_.bind(endpoint);
+    acceptor_.listen();
+
+    doAccept();
+    doTick();
+}
+
+Server::Server(asio::io_context &ioContext,
+               const std::string &address,
+               const std::string &port,
+               asio::ssl::context &sslCtx,
+               const Settings &settings,
+               size_t maxContentSize)
+    : ioContext_(ioContext),
+      acceptor_(ioContext),
+      sslCtx_(&sslCtx),
+      connectionManager_(settings),
+      requestHandler_(maxContentSize),
+      timer_(ioContext),
+      maxContentSize_(maxContentSize),
+      debugMsgCb_(defaultDebugMsgHandler) {
+    signals_ = std::make_shared<asio::signal_set>(ioContext);
+    signals_->add(SIGINT);
+    signals_->add(SIGTERM);
+#if defined(SIGQUIT)
+    signals_->add(SIGQUIT);
+#endif
+
+    if (maxContentSize < 1024) {
+        debugMsgCb_("maxContentSize must be equal or larger than 1024 bytes");
+        return;
+    }
+    doAwaitStop();
+
     asio::ip::tcp::resolver resolver(ioContext);
     asio::ip::tcp::endpoint endpoint = *resolver.resolve(address, port).begin();
     acceptor_.open(endpoint.protocol());
@@ -95,15 +164,41 @@ void Server::setDebugMsgHandler(const debugMsgCallback &cb) {
 }
 
 void Server::doAccept() {
+#ifdef BEAUTY_HAS_SSL
+    if (sslCtx_) {
+        // SSL accept: pre-create the SslSocket so we can accept on its
+        // underlying TCP socket, then let Connection::start() perform the
+        // TLS handshake before the first read.
+        auto sock = std::unique_ptr<SslSocket>(new SslSocket(ioContext_, *sslCtx_));
+        auto *rawTcp = &sock->tcpSocket();
+        acceptor_.async_accept(
+            *rawTcp,
+            [this, sock = std::move(sock)](std::error_code ec) mutable {
+                if (!acceptor_.is_open()) {
+                    return;
+                }
+                if (!ec) {
+                    connectionManager_.start(std::make_shared<Connection>(std::move(sock),
+                                                                         connectionManager_,
+                                                                         requestHandler_,
+                                                                         connectionId_++,
+                                                                         maxContentSize_));
+                } else {
+                    debugMsgCb_("doAccept(ssl): " + ec.message() + ":" +
+                                std::to_string(ec.value()));
+                }
+                doAccept();
+            });
+        return;
+    }
+#endif
     acceptor_.async_accept([this](std::error_code ec, asio::ip::tcp::socket socket) {
-        // Check whether the server was stopped by a signal before this
-        // completion handler had a chance to run.
         if (!acceptor_.is_open()) {
             return;
         }
-
         if (!ec) {
-            connectionManager_.start(std::make_shared<Connection>(std::move(socket),
+            auto sock = std::unique_ptr<PlainSocket>(new PlainSocket(std::move(socket)));
+            connectionManager_.start(std::make_shared<Connection>(std::move(sock),
                                                                   connectionManager_,
                                                                   requestHandler_,
                                                                   connectionId_++,
@@ -111,7 +206,6 @@ void Server::doAccept() {
         } else {
             debugMsgCb_("doAccept: " + ec.message() + ":" + std::to_string(ec.value()));
         }
-
         doAccept();
     });
 }

--- a/src/ws_client.cpp
+++ b/src/ws_client.cpp
@@ -13,7 +13,7 @@ WsClient::WsClient(asio::io_context &ioContext,
                    const Config &config)
     : ioContext_(ioContext),
       resolver_(ioContext),
-      socket_(ioContext),
+      socket_(std::unique_ptr<PlainSocket>(new PlainSocket(ioContext))),
       reconnectTimer_(ioContext),
       pingTimer_(ioContext),
       random_(random),
@@ -49,7 +49,7 @@ void WsClient::connect(const std::string &urlStr) {
     currentReconnectDelay_ = config_.reconnectInitialDelay;
 
     std::error_code ignore;
-    socket_.close(ignore);
+    socket_->close();
 
     resetForNewConnection();
     doResolve();
@@ -87,14 +87,21 @@ void WsClient::doResolve() {
 
 void WsClient::doConnect(const asio::ip::tcp::resolver::results_type &endpoints) {
     auto self(shared_from_this());
-    asio::async_connect(socket_,
+    socket_->asyncConnect(
                         endpoints,
                         [this, self](const std::error_code &ec, const asio::ip::tcp::endpoint &) {
                             if (ec) {
                                 handleDisconnect("Connect failed: " + ec.message());
                                 return;
                             }
-                            doWriteHandshake();
+                            // For SSL, perform TLS handshake before WebSocket upgrade.
+                            socket_->asyncHandshake(false, [this, self](const std::error_code &ec) {
+                                if (ec) {
+                                    handleDisconnect("TLS handshake failed: " + ec.message());
+                                    return;
+                                }
+                                doWriteHandshake();
+                            });
                         });
 }
 
@@ -114,8 +121,8 @@ void WsClient::doWriteHandshake() {
     sendBuffer_.assign(request.begin(), request.end());
 
     auto self(shared_from_this());
-    asio::async_write(
-        socket_, asio::buffer(sendBuffer_), [this, self](const std::error_code &ec, std::size_t) {
+    socket_->asyncWrite(
+        {asio::buffer(sendBuffer_)}, [this, self](const std::error_code &ec, std::size_t) {
             if (ec) {
                 handleDisconnect("Handshake write failed: " + ec.message());
                 return;
@@ -127,7 +134,7 @@ void WsClient::doWriteHandshake() {
 void WsClient::doReadHandshake() {
     auto self(shared_from_this());
     recvBuffer_.resize(config_.maxMessageSize);
-    socket_.async_read_some(
+    socket_->asyncReadSome(
         asio::buffer(recvBuffer_),
         [this, self](const std::error_code &ec, std::size_t bytesTransferred) {
             if (ec) {
@@ -228,7 +235,7 @@ void WsClient::doReadWs() {
     }
     size_t readSize = config_.maxMessageSize - wsParseOffset_;
     recvBuffer_.resize(wsParseOffset_ + readSize);
-    socket_.async_read_some(asio::buffer(recvBuffer_.data() + wsParseOffset_, readSize),
+    socket_->asyncReadSome(asio::buffer(recvBuffer_.data() + wsParseOffset_, readSize),
                             [this, self](const std::error_code &ec, std::size_t bytesTransferred) {
                                 if (ec) {
                                     handleDisconnect("Read failed: " + ec.message());
@@ -242,8 +249,8 @@ void WsClient::doReadWs() {
 void WsClient::doWriteWsFrame(bool continueReading, WriteCompleteCallback callback) {
     writeInProgress_ = true;
     auto self(shared_from_this());
-    asio::async_write(socket_,
-                      asio::buffer(sendBuffer_),
+    socket_->asyncWrite(
+                      {asio::buffer(sendBuffer_)},
                       [this, self, continueReading, callback](const std::error_code &ec,
                                                               std::size_t bytesWritten) {
                           writeInProgress_ = false;
@@ -350,7 +357,7 @@ void WsClient::finishConnection(bool notifyClose) {
 
     std::error_code ignore;
     pingTimer_.cancel();
-    socket_.close(ignore);
+    socket_->close();
 
     if (notifyClose) {
         handler_.onWsClose();
@@ -371,7 +378,7 @@ void WsClient::handleDisconnect(const std::string &error) {
 
     std::error_code ignore;
     pingTimer_.cancel();
-    socket_.close(ignore);
+    socket_->close();
 
     handler_.onWsError(error);
     if (wasOpen) {

--- a/src/ws_client.cpp
+++ b/src/ws_client.cpp
@@ -123,7 +123,7 @@ void WsClient::doWriteHandshake() {
     sendBuffer_.assign(request.begin(), request.end());
 
     auto self(shared_from_this());
-    socket_->asyncWrite({asio::buffer(sendBuffer_)},
+    socket_->asyncWrite(asio::buffer(sendBuffer_),
                         [this, self](const std::error_code& ec, std::size_t) {
                             if (ec) {
                                 handleDisconnect("Handshake write failed: " + ec.message());
@@ -251,7 +251,7 @@ void WsClient::doReadWs() {
 void WsClient::doWriteWsFrame(bool continueReading, WriteCompleteCallback callback) {
     writeInProgress_ = true;
     auto self(shared_from_this());
-    socket_->asyncWrite({asio::buffer(sendBuffer_)},
+    socket_->asyncWrite(asio::buffer(sendBuffer_),
                         [this, self, continueReading, callback](const std::error_code& ec,
                                                                 std::size_t bytesWritten) {
                             writeInProgress_ = false;

--- a/src/ws_client.cpp
+++ b/src/ws_client.cpp
@@ -52,7 +52,6 @@ void WsClient::connect(const std::string& urlStr) {
     reconnectEnabled_ = config_.autoReconnect;
     currentReconnectDelay_ = config_.reconnectInitialDelay;
 
-    std::error_code ignore;
     socket_->close();
 
     resetForNewConnection();
@@ -357,7 +356,6 @@ void WsClient::finishConnection(bool notifyClose) {
     finishing_ = true;
     isOpen_ = false;
 
-    std::error_code ignore;
     pingTimer_.cancel();
     socket_->close();
 
@@ -378,7 +376,6 @@ void WsClient::handleDisconnect(const std::string& error) {
     bool wasOpen = isOpen_;
     isOpen_ = false;
 
-    std::error_code ignore;
     pingTimer_.cancel();
     socket_->close();
 

--- a/src/ws_client.cpp
+++ b/src/ws_client.cpp
@@ -7,13 +7,14 @@
 
 namespace beauty {
 
-WsClient::WsClient(asio::io_context &ioContext,
-                   IRandom &random,
-                   IWsClientHandler &handler,
-                   const Config &config)
+WsClient::WsClient(asio::io_context& ioContext,
+                   IRandom& random,
+                   IWsClientHandler& handler,
+                   const Config& config,
+                   std::shared_ptr<ISocket> socket)
     : ioContext_(ioContext),
       resolver_(ioContext),
-      socket_(std::unique_ptr<PlainSocket>(new PlainSocket(ioContext))),
+      socket_(socket),
       reconnectTimer_(ioContext),
       pingTimer_(ioContext),
       random_(random),
@@ -24,12 +25,15 @@ WsClient::WsClient(asio::io_context &ioContext,
       wsMessage_(recvBuffer_),
       wsParser_(wsMessage_),
       currentReconnectDelay_(config.reconnectInitialDelay) {
+    if (!socket_) {
+        socket_.reset(new PlainSocket(ioContext));
+    }
     recvBuffer_.reserve(config_.maxMessageSize);
     sendBuffer_.reserve(config_.maxMessageSize);
     bodyBuffer_.reserve(config_.maxMessageSize);
 }
 
-void WsClient::connect(const std::string &urlStr) {
+void WsClient::connect(const std::string& urlStr) {
     if (!url_.parse(urlStr)) {
         handler_.onWsError("Invalid WebSocket URL");
         return;
@@ -75,8 +79,8 @@ void WsClient::doResolve() {
     auto self(shared_from_this());
     resolver_.async_resolve(host_,
                             port_,
-                            [this, self](const std::error_code &ec,
-                                         const asio::ip::tcp::resolver::results_type &endpoints) {
+                            [this, self](const std::error_code& ec,
+                                         const asio::ip::tcp::resolver::results_type& endpoints) {
                                 if (ec) {
                                     handleDisconnect("Resolve failed: " + ec.message());
                                     return;
@@ -85,24 +89,23 @@ void WsClient::doResolve() {
                             });
 }
 
-void WsClient::doConnect(const asio::ip::tcp::resolver::results_type &endpoints) {
+void WsClient::doConnect(const asio::ip::tcp::resolver::results_type& endpoints) {
     auto self(shared_from_this());
     socket_->asyncConnect(
-                        endpoints,
-                        [this, self](const std::error_code &ec, const asio::ip::tcp::endpoint &) {
-                            if (ec) {
-                                handleDisconnect("Connect failed: " + ec.message());
-                                return;
-                            }
-                            // For SSL, perform TLS handshake before WebSocket upgrade.
-                            socket_->asyncHandshake(false, [this, self](const std::error_code &ec) {
-                                if (ec) {
-                                    handleDisconnect("TLS handshake failed: " + ec.message());
-                                    return;
-                                }
-                                doWriteHandshake();
-                            });
-                        });
+        endpoints, [this, self](const std::error_code& ec, const asio::ip::tcp::endpoint&) {
+            if (ec) {
+                handleDisconnect("Connect failed: " + ec.message());
+                return;
+            }
+            // For SSL, perform TLS handshake before WebSocket upgrade.
+            socket_->asyncHandshake(false, [this, self](const std::error_code& ec) {
+                if (ec) {
+                    handleDisconnect("TLS handshake failed: " + ec.message());
+                    return;
+                }
+                doWriteHandshake();
+            });
+        });
 }
 
 void WsClient::doWriteHandshake() {
@@ -121,14 +124,14 @@ void WsClient::doWriteHandshake() {
     sendBuffer_.assign(request.begin(), request.end());
 
     auto self(shared_from_this());
-    socket_->asyncWrite(
-        {asio::buffer(sendBuffer_)}, [this, self](const std::error_code &ec, std::size_t) {
-            if (ec) {
-                handleDisconnect("Handshake write failed: " + ec.message());
-                return;
-            }
-            doReadHandshake();
-        });
+    socket_->asyncWrite({asio::buffer(sendBuffer_)},
+                        [this, self](const std::error_code& ec, std::size_t) {
+                            if (ec) {
+                                handleDisconnect("Handshake write failed: " + ec.message());
+                                return;
+                            }
+                            doReadHandshake();
+                        });
 }
 
 void WsClient::doReadHandshake() {
@@ -136,7 +139,7 @@ void WsClient::doReadHandshake() {
     recvBuffer_.resize(config_.maxMessageSize);
     socket_->asyncReadSome(
         asio::buffer(recvBuffer_),
-        [this, self](const std::error_code &ec, std::size_t bytesTransferred) {
+        [this, self](const std::error_code& ec, std::size_t bytesTransferred) {
             if (ec) {
                 handleDisconnect("Handshake read failed: " + ec.message());
                 return;
@@ -214,8 +217,8 @@ void WsClient::processWsBuffer() {
         if (isOpen_) {
             isOpen_ = false;
             wsEncoder_.encodeCloseFrame(1003, "Fragmented messages not supported");
-            doWriteWsFrame(
-                false, [this](const std::error_code &, std::size_t) { finishConnection(true); });
+            doWriteWsFrame(false,
+                           [this](const std::error_code&, std::size_t) { finishConnection(true); });
         }
     }
 }
@@ -230,60 +233,59 @@ void WsClient::doReadWs() {
         isOpen_ = false;
         wsEncoder_.encodeCloseFrame(1009, "Message too big");
         doWriteWsFrame(false,
-                       [this](const std::error_code &, std::size_t) { finishConnection(true); });
+                       [this](const std::error_code&, std::size_t) { finishConnection(true); });
         return;
     }
     size_t readSize = config_.maxMessageSize - wsParseOffset_;
     recvBuffer_.resize(wsParseOffset_ + readSize);
     socket_->asyncReadSome(asio::buffer(recvBuffer_.data() + wsParseOffset_, readSize),
-                            [this, self](const std::error_code &ec, std::size_t bytesTransferred) {
-                                if (ec) {
-                                    handleDisconnect("Read failed: " + ec.message());
-                                    return;
-                                }
-                                recvBuffer_.resize(wsParseOffset_ + bytesTransferred);
-                                processWsBuffer();
-                            });
+                           [this, self](const std::error_code& ec, std::size_t bytesTransferred) {
+                               if (ec) {
+                                   handleDisconnect("Read failed: " + ec.message());
+                                   return;
+                               }
+                               recvBuffer_.resize(wsParseOffset_ + bytesTransferred);
+                               processWsBuffer();
+                           });
 }
 
 void WsClient::doWriteWsFrame(bool continueReading, WriteCompleteCallback callback) {
     writeInProgress_ = true;
     auto self(shared_from_this());
-    socket_->asyncWrite(
-                      {asio::buffer(sendBuffer_)},
-                      [this, self, continueReading, callback](const std::error_code &ec,
-                                                              std::size_t bytesWritten) {
-                          writeInProgress_ = false;
-                          if (ec) {
-                              if (callback) {
-                                  callback(ec, bytesWritten);
-                              }
-                              handleDisconnect("Write failed: " + ec.message());
-                              return;
-                          }
-                          if (callback) {
-                              callback(ec, bytesWritten);
-                          }
-                          // If close() was called while this write was in
-                          // flight, now send the close frame.
-                          if (closePending_ && !closing_) {
-                              closePending_ = false;
-                              isOpen_ = false;
-                              closing_ = true;
-                              wsEncoder_.encodeCloseFrame(pendingCloseCode_, pendingCloseReason_);
-                              doWriteWsFrame(false,
-                                             [this, self](const std::error_code &, std::size_t) {
-                                                 finishConnection(true);
-                                             });
-                              return;
-                          }
-                          if (continueReading && isOpen_) {
-                              doReadWs();
-                          }
-                      });
+    socket_->asyncWrite({asio::buffer(sendBuffer_)},
+                        [this, self, continueReading, callback](const std::error_code& ec,
+                                                                std::size_t bytesWritten) {
+                            writeInProgress_ = false;
+                            if (ec) {
+                                if (callback) {
+                                    callback(ec, bytesWritten);
+                                }
+                                handleDisconnect("Write failed: " + ec.message());
+                                return;
+                            }
+                            if (callback) {
+                                callback(ec, bytesWritten);
+                            }
+                            // If close() was called while this write was in
+                            // flight, now send the close frame.
+                            if (closePending_ && !closing_) {
+                                closePending_ = false;
+                                isOpen_ = false;
+                                closing_ = true;
+                                wsEncoder_.encodeCloseFrame(pendingCloseCode_, pendingCloseReason_);
+                                doWriteWsFrame(false,
+                                               [this, self](const std::error_code&, std::size_t) {
+                                                   finishConnection(true);
+                                               });
+                                return;
+                            }
+                            if (continueReading && isOpen_) {
+                                doReadWs();
+                            }
+                        });
 }
 
-WriteResult WsClient::sendText(const std::string &text) {
+WriteResult WsClient::sendText(const std::string& text) {
     if (!isOpen_) {
         return WriteResult::CONNECTION_CLOSED;
     }
@@ -295,7 +297,7 @@ WriteResult WsClient::sendText(const std::string &text) {
     return WriteResult::SUCCESS;
 }
 
-WriteResult WsClient::sendBinary(const std::vector<char> &data) {
+WriteResult WsClient::sendBinary(const std::vector<char>& data) {
     if (!isOpen_) {
         return WriteResult::CONNECTION_CLOSED;
     }
@@ -315,7 +317,7 @@ void WsClient::sendPing() {
     doWriteWsFrame(false, nullptr);
 }
 
-void WsClient::close(uint16_t statusCode, const std::string &reason) {
+void WsClient::close(uint16_t statusCode, const std::string& reason) {
     reconnectEnabled_ = false;
     if (!isOpen_) {
         return;
@@ -330,7 +332,7 @@ void WsClient::close(uint16_t statusCode, const std::string &reason) {
     isOpen_ = false;
     closing_ = true;
     wsEncoder_.encodeCloseFrame(statusCode, reason);
-    doWriteWsFrame(false, [this](const std::error_code &, std::size_t) { finishConnection(true); });
+    doWriteWsFrame(false, [this](const std::error_code&, std::size_t) { finishConnection(true); });
 }
 
 void WsClient::startPingTimer() {
@@ -339,7 +341,7 @@ void WsClient::startPingTimer() {
     }
     auto self(shared_from_this());
     pingTimer_.expires_after(config_.pingInterval);
-    pingTimer_.async_wait([this, self](const std::error_code &ec) {
+    pingTimer_.async_wait([this, self](const std::error_code& ec) {
         if (ec || !isOpen_) {
             return;
         }
@@ -368,7 +370,7 @@ void WsClient::finishConnection(bool notifyClose) {
     }
 }
 
-void WsClient::handleDisconnect(const std::string &error) {
+void WsClient::handleDisconnect(const std::string& error) {
     if (finishing_) {
         return;
     }
@@ -401,7 +403,7 @@ void WsClient::scheduleReconnect() {
     }
     currentReconnectDelay_ = next;
 
-    reconnectTimer_.async_wait([this, self](const std::error_code &ec) {
+    reconnectTimer_.async_wait([this, self](const std::error_code& ec) {
         if (ec) {
             return;
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE BEAUTY_ENABLE_TESTING)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE Catch2::Catch2WithMain asio::asio cjson ${CMAKE_PROJECT_NAME})
 
+# OpenSSL and BEAUTY_ENABLE_SSL are inherited as PUBLIC from beauty_library
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)
 
 include_directories(

--- a/test/server_test.cpp
+++ b/test/server_test.cpp
@@ -982,55 +982,57 @@ TEST_CASE("server with PlainSocket serves HTTP through ISocket", "[server][isock
 #include "beauty/ssl_socket.hpp"
 
 // Self-signed test certificate and key (localhost, valid 2023–2033).
-// Generated with: openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 3650 -nodes -subj '/CN=localhost'
-// These are test-only and contain no secret value.
+// Generated with: openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 3650
+// -nodes -subj '/CN=localhost' These are test-only and contain no secret value.
 static const char TEST_CERT[] =
     "-----BEGIN CERTIFICATE-----\n"
-    "MIICpDCCAYwCCQDU+pQ4pHgSpDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls\n"
-    "b2NhbGhvc3QwHhcNMjMwMTAxMDAwMDAwWhcNMzMwMTAxMDAwMDAwWjAUMRIwEAYD\n"
-    "VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDF\n"
-    "By5VVFLhEa8ImoitTWdVtQUiMnE/OfS6V9+kC5LUohDy0jkte9KOtDT48T0sC9Xp\n"
-    "G7feZs+SMdiFURvMI3PShXwhtmNkN8CcpjKLD3tX8QLCQo+zX7Y66FDFFGUtgacG\n"
-    "2Mdkf7o+hIxOHsriQKcvBUE4fHiA6gg7Q/r9/DRgjDPj+BqoRFPaE9ms++1gU8Ko\n"
-    "ZVBgdOUwudgAtc99gKnwnbXW/idoAjay8wLCGNtc1Sf9A9CUOGGl9RpI6LIMrPyp\n"
-    "gL/AIn2IqJW4VJiqE4KwrJUE7v6MlsXVdzBSAT9we9YIS7IWvXtUtddlPaWBRlMh\n"
-    "cAhjgP2C7ebZQFhd1a0VAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAD3hYwP0JQ1t\n"
-    "L8nDvxmcT5E20RVdDAcANUjMJSkdd3teenoIm2LK5+QaCZeplrlv1KGVB5TY/ppj\n"
-    "9c3K/ysWxPRL4ht2AD68nhC8xvGKxQTdRIMPapNc1wksuj5L6F+4nPaUDNkfm1a6\n"
-    "nATR0B7XfOvjOfo6UkGyrOM2GEsMpJwPvxkR4ZWZVZxWPqOGqHAR9dOO9xBjNiOs\n"
-    "LcdMQlr+EEad1IoWNguGSia381XyZxajW1ecsAgGMRm9cFc0HZ1IofBuO4EwLjlq\n"
-    "cYMIFNk1T4XhEPjMb6SDTQPU0a7c+oYa64Yax8aFktUYaYxM/d3Adjgrpxibb5n8\n"
-    "OP3M0LElnsg=\n"
+    "MIIDCTCCAfGgAwIBAgIUHjkzHDahw+S7eqVS2BFtR09IRUAwDQYJKoZIhvcNAQEL\n"
+    "BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDcwNzEzNDQ1M1oXDTM2MDcw\n"
+    "NDEzNDQ1M1owFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF\n"
+    "AAOCAQ8AMIIBCgKCAQEAxSyeOmNSfsGCwv5xr4Eb6GI6vGeNlU0TcJjpBeh1H8/i\n"
+    "AKgjJKdGqWL3nOQWx21uZM7djQKb7UpsmNmFHTXilN4OUrbsoJvEEFvLb0sX0IYA\n"
+    "KECZZvMkiA7MwDo8TOw+/PpVspUnnkpB3PaMeX/rfUCwR/DU1JZzCi/acLcZy8oJ\n"
+    "GhLvoqmZ6BfJbTDFvw6PBwmSkGqLBu7ZQRgEeJ4pCoNkj03DAGTEkjrOUPK2ywzq\n"
+    "2g3Z+ImbmfgdmwVQFsQIgBCHKpcf3jSSaUKv5YWiZFnOep0z7W7MuI7Kynp7o/G+\n"
+    "IuBWpqhUBRNhTAM4/Vhkl/5Qo3lXOgmOaT3/0tsacwIDAQABo1MwUTAdBgNVHQ4E\n"
+    "FgQU0rop38elBlEjWcykuyTQ3rHSt68wHwYDVR0jBBgwFoAU0rop38elBlEjWcyk\n"
+    "uyTQ3rHSt68wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEARQ01\n"
+    "47UGwF9keWuNLMN+ge5B+LHu7I8pSKDDeILlqQwQ8Mvv5v4ZHch7KxZXr2adgHOF\n"
+    "LthcakXJiFHYnLb2V/1e2gOeyZnYYKBDi2xoq7mT03jZF8ZMZIHOdK4pEzOv1H/K\n"
+    "uGH9qQvijjBznhAZQXwQXuUohxu8fMx40XMUN/t+VWxqVGjjfIZmfjYaPpg8j9TO\n"
+    "X//yB5g+/Rolmt8F4/x6pfr8UZWUH4ubz+fxh939474SlTtWCGtQVGhxhPfl32R9\n"
+    "iAhP0OpDnkSTJByCjcilKhmwpkxf5ThG8v6qEgcrLOKpTFzhYOHTyuLntRKKcYgo\n"
+    "YbgHN0DAKn5U88Ybhw==\n"
     "-----END CERTIFICATE-----\n";
 
 static const char TEST_KEY[] =
     "-----BEGIN PRIVATE KEY-----\n"
-    "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDFBy5VVFLhEa8I\n"
-    "moitTWdVtQUiMnE/OfS6V9+kC5LUohDy0jkte9KOtDT48T0sC9XpG7feZs+SMdiF\n"
-    "URvMI3PShXwhtmNkN8CcpjKLD3tX8QLCQo+zX7Y66FDFFGUtgacG2Mdkf7o+hIxO\n"
-    "HsriQKcvBUE4fHiA6gg7Q/r9/DRgjDPj+BqoRFPaE9ms++1gU8KoZVBgdOUwudgA\n"
-    "tc99gKnwnbXW/idoAjay8wLCGNtc1Sf9A9CUOGGl9RpI6LIMrPypgL/AIn2IqJW4\n"
-    "VJiqE4KwrJUE7v6MlsXVdzBSAT9we9YIS7IWvXtUtddlPaWBRlMhcAhjgP2C7ebZ\n"
-    "QFhd1a0VAgMBAAECggEAPY3+WwBVfvgIitFoiv3QOujdukONjJKZxX7NPhw2ppGU\n"
-    "z5OzMkhi7CIdfQd5oqJM5bLE5eQGNR9Ar6wNBYQyXLcJAZjj45hOGlbTdS84aG58\n"
-    "DQXVoBgkW3jZyyoue0IFSDg5Fm3FYotcT8PuMk4hQbj6wJ9/DP6NNupD6ncjwVAh\n"
-    "UsFYovwlupVXTQAZzrP7j9f4buJFNy61BZ6oh2gQKttr3VENyQXeQrAqJws3BOhM\n"
-    "nKGesXv4dkVc3Gvs4MyG/krla+JKtk+8mG5URQrRz9YNrRtLLUYEfBfavIJqn3TC\n"
-    "tMqJA1PQuAApDI5FkWQCfQiYR/+3ENJRVurYqvY24QKBgQDl8dyLQDIgZYFxny5D\n"
-    "ptWTkUQlXde2dVTkwy2MZMZf1MNXokv+ft2/qFLMil0pP8NmVvsGe3MHXPsJhYRN\n"
-    "JXVgGikA1451n+KRilX06mIu4/7KNalE0HfE7y/IRC5yCqzlQSjB02ZJi/uVEfm1\n"
-    "VEHLcRNr2MB0uJ3vXvRaM0GnKQKBgQDb183N1wFrolvyI0uxQXjy2YSQrOAZRgXm\n"
-    "8woOiDVTHUlCcYlQEhHy3EJBcpnvHirC3wTfba2rQc3bE/jTKVTeRKUJL945mvZF\n"
-    "4hfBBl3Kv4AP9yGmHPmmQrHkIFEeNMMK5+x9DGgEAPVy5Yb4+4AxHlpM4CzQpxpb\n"
-    "wadIR+QxbQKBgF8hFrFlISBsYM+/Zn2eKhTQaqeKFhgRLUHGeNuVn7qkFlXo6F2h\n"
-    "eAEonylmuFTg3Pug3xcXJ7z1IYmrBIoVwfCGu3wz3IMWMAPKDtRYBGA9IZJhg8OW\n"
-    "IYq7UkOooT3Sybhjhcog1dMlCMlakBx0yIN3rtrL7GWc/lVT2eTP/oMbAoGAQ+Y2\n"
-    "kWNoz0pyjXvm+8yR8xAAwb/XKKtMIi73F9GyTaKg32Uu+OYwXGhbLSjfpggJvrAQ\n"
-    "VVHzsjgIDRSmpULihCzrnSyBJwPecVfq+mBrCHeFaBKQqvdRFXNsuyxmxk55jcSB\n"
-    "VCltAGf0k0YrYc3XtkiGfkVPDS1DY0OiaIEcEiECgYBTZzdAqiFhFeP0PPXEy4ws\n"
-    "eZy2iOYed/+6PnFYyGcgFGnfNfO7tierpJ5yV25HZsfETSfNYOkOAziaOXpxuCgW\n"
-    "M1eJkk6AfRgWSOCbRGP663kQKXXpCYKkabwgwFZosuAmzmiQZtitEHIGWQ2iQnbg\n"
-    "/6Yislltc5oe2KRUzD6MJw==\n"
+    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDFLJ46Y1J+wYLC\n"
+    "/nGvgRvoYjq8Z42VTRNwmOkF6HUfz+IAqCMkp0apYvec5BbHbW5kzt2NApvtSmyY\n"
+    "2YUdNeKU3g5Stuygm8QQW8tvSxfQhgAoQJlm8ySIDszAOjxM7D78+lWylSeeSkHc\n"
+    "9ox5f+t9QLBH8NTUlnMKL9pwtxnLygkaEu+iqZnoF8ltMMW/Do8HCZKQaosG7tlB\n"
+    "GAR4nikKg2SPTcMAZMSSOs5Q8rbLDOraDdn4iZuZ+B2bBVAWxAiAEIcqlx/eNJJp\n"
+    "Qq/lhaJkWc56nTPtbsy4jsrKenuj8b4i4FamqFQFE2FMAzj9WGSX/lCjeVc6CY5p\n"
+    "Pf/S2xpzAgMBAAECggEAGRFPHIU8G7lmcnv+4B09+xFh/kn8Chs+eXY3SfT/zweS\n"
+    "6Bp4PVS2+xoF+QBWlQwomNBkAmVuhYCMxfIBpnEPWXXRxFpVQyYKizngZ0nYwT4I\n"
+    "DxYHartGzbVz+oxs1irC5068TnQAEXPHY9xEh73npoju4HaR2GU4QvdKgkIFGY9g\n"
+    "nI+YmW4Mlij3bUR1mpEVDGtPZjxtIfUYt7fDsJAJ9P6NYpN41xT2AqnWg/FV5MLX\n"
+    "4hG9woo80CVs1+LA7gUyG49Y6nX+D9A5d6QhWvWhipETmi0bwXimrUAtl8wYqY7k\n"
+    "zfDPBw36tNM6R9Sb71oH1u6vAPgxLcs1ypcUFzt/QQKBgQD6BlYtRxwG2HSZUE5d\n"
+    "bgCEqBeH+KEO21R5apBS5VOrRSjUFZbxxgXaTXj1afSjr43qPAoS69GiXe0xsWgP\n"
+    "jAo4ONIibr/qDJGBdiWkI7pzq4auSXLDqPydXpcsQGdVn9tdtzQzfxTxbkC6Ys51\n"
+    "WPHv5dhRgBSh3oAze/yj6yRWGQKBgQDJ4vCWU/mKkxel56we2kBRe9DdMggPdCsR\n"
+    "ZysLppg1mNkzZ94KTEI+9T7sRAg4CSlSUUaEbe6vDYSP0geofcGNZc0QvNt+44KU\n"
+    "0zu9f3WBjN59II1vsk5LMPQ2sJ0HHghqmHsxib3asuhPT/v95dhon0RqkC8uWkus\n"
+    "G69FltvOawKBgAZmzyINpgwO0r1yLu95d43t99xFY2pL91e8gMF+mavS836qpti9\n"
+    "5zx1q1ktQ1RFlG6g5ukhHJb5rK8PCckMHt7dpZO4HjXR6I/WBJS1TXrUs3gW7VdR\n"
+    "JlapK1m4tGye0TEPFckTweeEmSesi/i5NEieK/G6Q8z5M3MeA5P221FRAoGAIenG\n"
+    "YmpO0/Frmon1RuWAwm9bIZ0i732jMnQzLezZSr+XVORQz0gKJMtLu6KeAtO/Jj3S\n"
+    "67IP00YhC4vLj4k4d0kvjm07LfCH4fot4eJEWfPQ+BH80FOShVz+2SUH68cmwMlG\n"
+    "gIbT5qYBEjmsafUvSjve4UvBMTcn2Qx5f+YcnGsCgYEAwbDwGUDWqGyd2BuJ0PJm\n"
+    "Gxcqw5EavqJQUZpJpPRrNfczJH09i9OyavOfOL/e63SiUnNhPEieQMsv/Gi3v+DI\n"
+    "s5xQ81EqrQqL971z1GTPoTdIax6NY4OODOk8WBtg83XYihOfUMGyJRsMkLfDhA8I\n"
+    "Wdh4yNc0TsVClf4VExc++1g=\n"
     "-----END PRIVATE KEY-----\n";
 
 TEST_CASE("SslSocket properties", "[server][ssl]") {
@@ -1058,11 +1060,9 @@ TEST_CASE("SSL server accepts TLS connections", "[server][ssl]") {
 
     // Set up SSL context with test certificate
     asio::ssl::context sslCtx(asio::ssl::context::tlsv12);
-    sslCtx.set_options(asio::ssl::context::default_workarounds |
-                       asio::ssl::context::no_sslv2);
+    sslCtx.set_options(asio::ssl::context::default_workarounds | asio::ssl::context::no_sslv2);
     sslCtx.use_certificate_chain(asio::buffer(TEST_CERT, sizeof(TEST_CERT)));
-    sslCtx.use_private_key(asio::buffer(TEST_KEY, sizeof(TEST_KEY)),
-                           asio::ssl::context::pem);
+    sslCtx.use_private_key(asio::buffer(TEST_KEY, sizeof(TEST_KEY)), asio::ssl::context::pem);
 
     Settings settings(0s, 0, 0);
     Server dut(ioc, "127.0.0.1", "0", sslCtx, settings);

--- a/test/server_test.cpp
+++ b/test/server_test.cpp
@@ -976,3 +976,135 @@ TEST_CASE("server with PlainSocket serves HTTP through ISocket", "[server][isock
     ioc.stop();
     t.join();
 }
+
+#ifdef BEAUTY_ENABLE_SSL
+#include <asio/ssl.hpp>
+#include "beauty/ssl_socket.hpp"
+
+// Self-signed test certificate and key (localhost, valid 2023–2033).
+// Generated with: openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 3650 -nodes -subj '/CN=localhost'
+// These are test-only and contain no secret value.
+static const char TEST_CERT[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIICpDCCAYwCCQDU+pQ4pHgSpDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls\n"
+    "b2NhbGhvc3QwHhcNMjMwMTAxMDAwMDAwWhcNMzMwMTAxMDAwMDAwWjAUMRIwEAYD\n"
+    "VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDF\n"
+    "By5VVFLhEa8ImoitTWdVtQUiMnE/OfS6V9+kC5LUohDy0jkte9KOtDT48T0sC9Xp\n"
+    "G7feZs+SMdiFURvMI3PShXwhtmNkN8CcpjKLD3tX8QLCQo+zX7Y66FDFFGUtgacG\n"
+    "2Mdkf7o+hIxOHsriQKcvBUE4fHiA6gg7Q/r9/DRgjDPj+BqoRFPaE9ms++1gU8Ko\n"
+    "ZVBgdOUwudgAtc99gKnwnbXW/idoAjay8wLCGNtc1Sf9A9CUOGGl9RpI6LIMrPyp\n"
+    "gL/AIn2IqJW4VJiqE4KwrJUE7v6MlsXVdzBSAT9we9YIS7IWvXtUtddlPaWBRlMh\n"
+    "cAhjgP2C7ebZQFhd1a0VAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAD3hYwP0JQ1t\n"
+    "L8nDvxmcT5E20RVdDAcANUjMJSkdd3teenoIm2LK5+QaCZeplrlv1KGVB5TY/ppj\n"
+    "9c3K/ysWxPRL4ht2AD68nhC8xvGKxQTdRIMPapNc1wksuj5L6F+4nPaUDNkfm1a6\n"
+    "nATR0B7XfOvjOfo6UkGyrOM2GEsMpJwPvxkR4ZWZVZxWPqOGqHAR9dOO9xBjNiOs\n"
+    "LcdMQlr+EEad1IoWNguGSia381XyZxajW1ecsAgGMRm9cFc0HZ1IofBuO4EwLjlq\n"
+    "cYMIFNk1T4XhEPjMb6SDTQPU0a7c+oYa64Yax8aFktUYaYxM/d3Adjgrpxibb5n8\n"
+    "OP3M0LElnsg=\n"
+    "-----END CERTIFICATE-----\n";
+
+static const char TEST_KEY[] =
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDFBy5VVFLhEa8I\n"
+    "moitTWdVtQUiMnE/OfS6V9+kC5LUohDy0jkte9KOtDT48T0sC9XpG7feZs+SMdiF\n"
+    "URvMI3PShXwhtmNkN8CcpjKLD3tX8QLCQo+zX7Y66FDFFGUtgacG2Mdkf7o+hIxO\n"
+    "HsriQKcvBUE4fHiA6gg7Q/r9/DRgjDPj+BqoRFPaE9ms++1gU8KoZVBgdOUwudgA\n"
+    "tc99gKnwnbXW/idoAjay8wLCGNtc1Sf9A9CUOGGl9RpI6LIMrPypgL/AIn2IqJW4\n"
+    "VJiqE4KwrJUE7v6MlsXVdzBSAT9we9YIS7IWvXtUtddlPaWBRlMhcAhjgP2C7ebZ\n"
+    "QFhd1a0VAgMBAAECggEAPY3+WwBVfvgIitFoiv3QOujdukONjJKZxX7NPhw2ppGU\n"
+    "z5OzMkhi7CIdfQd5oqJM5bLE5eQGNR9Ar6wNBYQyXLcJAZjj45hOGlbTdS84aG58\n"
+    "DQXVoBgkW3jZyyoue0IFSDg5Fm3FYotcT8PuMk4hQbj6wJ9/DP6NNupD6ncjwVAh\n"
+    "UsFYovwlupVXTQAZzrP7j9f4buJFNy61BZ6oh2gQKttr3VENyQXeQrAqJws3BOhM\n"
+    "nKGesXv4dkVc3Gvs4MyG/krla+JKtk+8mG5URQrRz9YNrRtLLUYEfBfavIJqn3TC\n"
+    "tMqJA1PQuAApDI5FkWQCfQiYR/+3ENJRVurYqvY24QKBgQDl8dyLQDIgZYFxny5D\n"
+    "ptWTkUQlXde2dVTkwy2MZMZf1MNXokv+ft2/qFLMil0pP8NmVvsGe3MHXPsJhYRN\n"
+    "JXVgGikA1451n+KRilX06mIu4/7KNalE0HfE7y/IRC5yCqzlQSjB02ZJi/uVEfm1\n"
+    "VEHLcRNr2MB0uJ3vXvRaM0GnKQKBgQDb183N1wFrolvyI0uxQXjy2YSQrOAZRgXm\n"
+    "8woOiDVTHUlCcYlQEhHy3EJBcpnvHirC3wTfba2rQc3bE/jTKVTeRKUJL945mvZF\n"
+    "4hfBBl3Kv4AP9yGmHPmmQrHkIFEeNMMK5+x9DGgEAPVy5Yb4+4AxHlpM4CzQpxpb\n"
+    "wadIR+QxbQKBgF8hFrFlISBsYM+/Zn2eKhTQaqeKFhgRLUHGeNuVn7qkFlXo6F2h\n"
+    "eAEonylmuFTg3Pug3xcXJ7z1IYmrBIoVwfCGu3wz3IMWMAPKDtRYBGA9IZJhg8OW\n"
+    "IYq7UkOooT3Sybhjhcog1dMlCMlakBx0yIN3rtrL7GWc/lVT2eTP/oMbAoGAQ+Y2\n"
+    "kWNoz0pyjXvm+8yR8xAAwb/XKKtMIi73F9GyTaKg32Uu+OYwXGhbLSjfpggJvrAQ\n"
+    "VVHzsjgIDRSmpULihCzrnSyBJwPecVfq+mBrCHeFaBKQqvdRFXNsuyxmxk55jcSB\n"
+    "VCltAGf0k0YrYc3XtkiGfkVPDS1DY0OiaIEcEiECgYBTZzdAqiFhFeP0PPXEy4ws\n"
+    "eZy2iOYed/+6PnFYyGcgFGnfNfO7tierpJ5yV25HZsfETSfNYOkOAziaOXpxuCgW\n"
+    "M1eJkk6AfRgWSOCbRGP663kQKXXpCYKkabwgwFZosuAmzmiQZtitEHIGWQ2iQnbg\n"
+    "/6Yislltc5oe2KRUzD6MJw==\n"
+    "-----END PRIVATE KEY-----\n";
+
+TEST_CASE("SslSocket properties", "[server][ssl]") {
+    asio::io_context ioc;
+    asio::ssl::context sslCtx(asio::ssl::context::tlsv12);
+
+    SECTION("needsHandshake should return true") {
+        SslSocket sock(ioc, sslCtx);
+        REQUIRE(sock.needsHandshake() == true);
+    }
+
+    SECTION("it should report not open when freshly constructed") {
+        SslSocket sock(ioc, sslCtx);
+        REQUIRE(sock.isOpen() == false);
+    }
+
+    SECTION("it should close without error when not open") {
+        SslSocket sock(ioc, sslCtx);
+        sock.close();  // Should not throw
+    }
+}
+
+TEST_CASE("SSL server accepts TLS connections", "[server][ssl]") {
+    asio::io_context ioc;
+
+    // Set up SSL context with test certificate
+    asio::ssl::context sslCtx(asio::ssl::context::tlsv12);
+    sslCtx.set_options(asio::ssl::context::default_workarounds |
+                       asio::ssl::context::no_sslv2);
+    sslCtx.use_certificate_chain(asio::buffer(TEST_CERT, sizeof(TEST_CERT)));
+    sslCtx.use_private_key(asio::buffer(TEST_KEY, sizeof(TEST_KEY)),
+                           asio::ssl::context::pem);
+
+    Settings settings(0s, 0, 0);
+    Server dut(ioc, "127.0.0.1", "0", sslCtx, settings);
+    uint16_t port = dut.getBindedPort();
+    REQUIRE(port != 0);
+
+    auto t = std::thread(&asio::io_context::run, &ioc);
+
+    SECTION("TLS handshake and HTTP request/response cycle") {
+        // Use an SSL client socket to connect, handshake, and send a request
+        asio::ssl::context clientCtx(asio::ssl::context::tlsv12_client);
+        clientCtx.set_verify_mode(asio::ssl::verify_none);  // Self-signed cert
+
+        asio::ip::tcp::resolver resolver(ioc);
+        auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
+
+        asio::ssl::stream<asio::ip::tcp::socket> clientStream(ioc, clientCtx);
+        asio::connect(clientStream.next_layer(), endpoints);
+        clientStream.handshake(asio::ssl::stream_base::client);
+
+        // Send a simple HTTP request over TLS
+        std::string request = GetIndexRequest;
+        asio::write(clientStream, asio::buffer(request));
+
+        // Read the response
+        asio::streambuf response;
+        std::error_code ec;
+        asio::read_until(clientStream, response, "\r\n", ec);
+
+        std::istream responseStream(&response);
+        std::string httpVersion;
+        unsigned int statusCode;
+        responseStream >> httpVersion >> statusCode;
+
+        REQUIRE(httpVersion == "HTTP/1.1");
+        // Without handlers, server returns 501
+        REQUIRE(statusCode == 501);
+
+        clientStream.shutdown(ec);  // Ignore shutdown errors
+    }
+
+    ioc.stop();
+    t.join();
+}
+#endif  // BEAUTY_ENABLE_SSL

--- a/test/server_test.cpp
+++ b/test/server_test.cpp
@@ -10,6 +10,7 @@
 #include "utils/test_client.hpp"
 
 #include "beauty/server.hpp"
+#include "beauty/i_socket.hpp"
 #include "beauty/request_handler.hpp"
 
 using namespace std::literals::chrono_literals;
@@ -901,6 +902,75 @@ TEST_CASE("server with write fileIO with 100-continue support", "[server]") {
         auto res = fut.get();
 
         REQUIRE(res.statusCode_ == 417);  // Expectation Failed
+    }
+
+    ioc.stop();
+    t.join();
+}
+
+// --- ISocket / PlainSocket tests ---
+// Verify that the ISocket abstraction layer works correctly with PlainSocket,
+// ensuring the refactoring for SSL support does not break plain HTTP.
+
+TEST_CASE("PlainSocket implements ISocket interface", "[server][isocket]") {
+    asio::io_context ioc;
+
+    SECTION("it should report not open when freshly constructed") {
+        PlainSocket sock(ioc);
+        REQUIRE(sock.isOpen() == false);
+    }
+
+    SECTION("it should expose the underlying tcp socket") {
+        PlainSocket sock(ioc);
+        asio::ip::tcp::socket& ref = sock.tcpSocket();
+        REQUIRE(ref.is_open() == false);
+    }
+
+    SECTION("it should close without error when not open") {
+        PlainSocket sock(ioc);
+        sock.close();  // Should not throw
+    }
+
+    SECTION("asyncHandshake should complete synchronously with success") {
+        PlainSocket sock(ioc);
+        bool called = false;
+        std::error_code result;
+        sock.asyncHandshake(true, [&](const std::error_code& ec) {
+            called = true;
+            result = ec;
+        });
+        // PlainSocket::asyncHandshake calls the handler synchronously
+        REQUIRE(called == true);
+        REQUIRE(!result);
+    }
+
+    SECTION("needsHandshake should return false") {
+        PlainSocket sock(ioc);
+        REQUIRE(sock.needsHandshake() == false);
+    }
+}
+
+TEST_CASE("server with PlainSocket serves HTTP through ISocket", "[server][isocket]") {
+    // This test verifies that the Connection→ISocket refactoring does not
+    // break the plain HTTP path.  It exercises the full accept→handshake→
+    // read→write→close cycle through PlainSocket.
+    asio::io_context ioc;
+    TestClient c(ioc);
+
+    Settings settings(0s, 0, 0);
+    Server dut(ioc, "127.0.0.1", "0", settings);
+    uint16_t port = dut.getBindedPort();
+    auto t = std::thread(&asio::io_context::run, &ioc);
+
+    SECTION("GET request works through ISocket PlainSocket path") {
+        openConnection(c, "127.0.0.1", port);
+        auto fut = createFutureResult(c);
+        c.sendRequest(GetIndexRequest);
+
+        auto res = fut.get();
+        REQUIRE(res.action_ == TestClient::TestResult::ReadContent);
+        // Without handlers, server returns 501 Not Implemented
+        REQUIRE(res.statusCode_ == 501);
     }
 
     ioc.stop();

--- a/test/server_test.cpp
+++ b/test/server_test.cpp
@@ -981,7 +981,7 @@ TEST_CASE("server with PlainSocket serves HTTP through ISocket", "[server][isock
 #include <asio/ssl.hpp>
 #include "beauty/ssl_socket.hpp"
 
-// Self-signed test certificate and key (localhost, valid 2023–2033).
+// Self-signed test certificate and key (localhost, valid 2026–2036).
 // Generated with: openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 3650
 // -nodes -subj '/CN=localhost' These are test-only and contain no secret value.
 static const char TEST_CERT[] =


### PR DESCRIPTION
This PR brings ssl/tls to Beauty through ASIO's SSL layer. On ESP-IDF the underlying crypto is provided by mbedTLS (hardware-accelerated on most ESP32 variants); on PC/Linux it uses OpenSSL.

Too keep the `Connection`, `HttpClient`, and `WsClient` as non-template classes, SSL/TLS is implemented through a type-erased socket interface (`ISocket`) with two implementations:

- `PlainSocket` — wraps `asio::ip::tcp::socket` (no encryption)
- `SslSocket` — wraps `asio::ssl::stream<tcp::socket>` (TLS encryption)

The virtual dispatch cost per I/O operation is negligible compared to actual network and crypto processing.

Tests was successfully  performed on ESP32 with `curl -k https://<ip address>`  using a modified template_app.
The certificate used was generated with step-ca according to https://stackoverflowteams.com/c/paneda/questions/265. The crt.pem/key.pem was stored on LittleFs and read/feed to the new constructors.

All unit tests pass. However it was noticed that the already flaky server_test.cpp is potentially now even more flaky. I think this needs to be addressed in a seperate task.